### PR TITLE
[Feat] #80 운동 매칭 기능 구현

### DIFF
--- a/FitMate/FitMate/Common/Service/Firebase/Firestore/FirestoreService.swift
+++ b/FitMate/FitMate/Common/Service/Firebase/Firestore/FirestoreService.swift
@@ -102,7 +102,7 @@ class FirestoreService {
         )
      */
     
-    func createMatchDocument(inviterUid: String, inviteeUid: String, exerciseType: String, goalValue: String, mode: String) -> Single<Void> {
+    func createMatchDocument(inviterUid: String, inviteeUid: String, exerciseType: String, goalValue: String, mode: String) -> Single<String> {
         return Single.create { single in
             func tryGenerateAndSave() {
                 let matchCode = self.generateInviteCode()
@@ -123,7 +123,7 @@ class FirestoreService {
                             "createAt": FieldValue.serverTimestamp(), // 만든 시간
                             // "startedAt": FieldValue.serverTimestamp(),     // 실제 시작 시각 넣을 땐 따로 업데이트
                             // "finishedAt": FieldValue.serverTimestamp(),    // 실제 종료 시각 넣을 땐 따로 업데이트
-                            "player": [
+                            "players": [
                                 inviterUid: [
                                     // "avatar": "끼리꼬", // 아바타 구현 되면 넣어야됨
                                     "isOnline": true,
@@ -141,14 +141,15 @@ class FirestoreService {
                             ]
                         ]
                         
-                        // Match 컬렉션의 MatchID 문서 생성
+                        // Match 컬렉션의 MatchCode 문서 생성
                         // 데이터 생성
                         newRef.setData(data) { error in
                             if let error = error {
                                 single(.failure(error))
                                 print("Match 데이터 생성 실패: \(error.localizedDescription)")
                             } else {
-                                single(.success(()))
+                                // MatchCode 반환
+                                single(.success(newRef.documentID))
                                 print("Match 데이터 생성 완료: 매치코드: \(matchCode)")
                             }
                         }

--- a/FitMate/FitMate/Common/Service/Firebase/Firestore/MatchEventService.swift
+++ b/FitMate/FitMate/Common/Service/Firebase/Firestore/MatchEventService.swift
@@ -21,7 +21,7 @@ final class MatchEventService {
     let matchEventRelay = PublishRelay<String>() // matchCode 데이터
     
     // matchCode 별 status 이벤트 스트림
-    let matchStatusRelay = PublishRelay<(matchId: String, status: String)>()
+    let matchStatusRelay = PublishRelay<(matchCode: String, status: String)>()
     
     private init() { }
     

--- a/FitMate/FitMate/Common/Service/Firebase/Firestore/MatchEventService.swift
+++ b/FitMate/FitMate/Common/Service/Firebase/Firestore/MatchEventService.swift
@@ -1,0 +1,87 @@
+//
+//  MatchEventService.swift
+//  FitMate
+//
+//  Created by NH on 6/16/25.
+//
+
+import FirebaseFirestore
+import RxSwift
+import RxRelay
+
+/// Firestore 글로벌 실시간 감지 리스너
+final class MatchEventService {
+    static let shared = MatchEventService()
+    
+    // 글로벌 실시간 감지 리스너 생성
+    private var matchListener: ListenerRegistration? // 운동 초대 감지 리스너
+    private var listener: ListenerRegistration? // 운동 초대 응답 감지 리스너
+    
+    // 매칭 이벤트 Relay
+    let matchEventRelay = PublishRelay<String>() // matchCode 데이터
+    
+    // matchCode 별 status 이벤트 스트림
+    let matchStatusRelay = PublishRelay<(matchId: String, status: String)>()
+    
+    private init() { }
+    
+    // MARK: - 운동 초대 감지
+    func startListening(for uid: String) {
+        stopMatchListening()
+        
+        let db = Firestore.firestore()
+        
+        matchListener = db.collection("matches")
+            .whereField("inviteeUid", isEqualTo: uid) // 초대 받는 유저의 uid가 내 uid 일때
+            .whereField("matchStatus", isEqualTo: "waiting") // 운동 경기 상태가 waiting 일때
+            .addSnapshotListener { [weak self] snapshot, error in // 실시간으로 감지해서 쿼리 결과 혹은 에러를 방출
+                guard let self = self,
+                      // 쿼리 결과를 배열로 받아오지만, 쿼리 결과는 유일하므로 첫번째 값을 꺼냄
+                      let doc = snapshot?.documents.first,
+                      error == nil else { return }
+                
+                // 쿼리 결과의 matchCode를 방출
+                let matchCode = doc.documentID
+                self.matchEventRelay.accept(matchCode)
+            }
+    }
+    
+    /// 전역 리스너 해제 메서드
+    func stopMatchListening() {
+        matchListener?.remove()
+        matchListener = nil
+    }
+    
+    // 특정 matchCode 의 상태 변화를 구독
+    // MARK: - 운동 초대 수락 감지
+    func listenMatchStatus(matchCode: String) {
+        stopListening()
+        let db = Firestore.firestore()
+        
+        print("listenMatchStatus 등록, matchId: \(matchCode)")
+        
+        listener = db.collection("matches").document(matchCode) // 특정 운동 경기 실시간 감지
+            .addSnapshotListener { [weak self] snapshot, error in
+                print("addSnapshotListener 콜백 호출")
+                
+                guard let self = self,
+                      // 결과를 딕셔너리 형태로 변형
+                      let data = snapshot?.data(),
+                      // matchStatus 의 값을 추출
+                      let status = data["matchStatus"] as? String else {
+                    print("콜백에서 데이터 없음, error: \(String(describing: error))")
+                    return
+                }
+                print("Firestore에서 matchStatus 변화 감지: \(status)")
+                
+                // 운동 경기 코드와, 해당 운동 경기의 상태를 방출!
+                self.matchStatusRelay.accept((matchCode, status))
+            }
+    }
+    
+    /// 전역 리스너 해제 메서드
+    func stopListening() {
+        listener?.remove()
+        listener = nil
+    }
+}

--- a/FitMate/FitMate/Scene/GoalSelection/View/GoalSelectionViewController.swift
+++ b/FitMate/FitMate/Scene/GoalSelection/View/GoalSelectionViewController.swift
@@ -127,8 +127,8 @@ class GoalSelectionViewController: BaseViewController, UIPickerViewDataSource, U
                 guard let self = self else { return }
                 
                 // 저장(종목 타이틀, 목표치)
-                let selectedMode = self.selectedModeRelay.value // 운동 모드 저장
-                let selectedGoal = self.selectedGoalRelay.value // 운동 목표 저장
+//                let selectedMode = self.selectedModeRelay.value // 운동 모드 저장
+//                let selectedGoal = self.selectedGoalRelay.value // 운동 목표 저장
                 
                 // MARK: Firestore 데이터 저장
                 // "matches" 컬렉션 및 "matchID" 문서 생성

--- a/FitMate/FitMate/Scene/GoalSelection/View/GoalSelectionViewController.swift
+++ b/FitMate/FitMate/Scene/GoalSelection/View/GoalSelectionViewController.swift
@@ -140,12 +140,15 @@ class GoalSelectionViewController: BaseViewController, UIPickerViewDataSource, U
                     mode: self.selectedModeRelay.value.asString
                 )
                 .subscribe(
-                    onSuccess: { print("Match 생성 성공") },
+                    onSuccess: { matchCode in
+                        print("Match 생성 성공 \(matchCode)")
+                        // 로딩 화면으로 이동
+                        self.navigationController?.pushViewController(LoadingViewController(matchCode: matchCode), animated: true)
+                    },
                     onFailure: { error in print("실패: \(error)") }
                 ).disposed(by: disposeBag)
                 
-                // 로딩 화면으로 이동
-                self.navigationController?.pushViewController(LoadingViewController(), animated: true)
+                
 
             })
             .disposed(by: disposeBag)

--- a/FitMate/FitMate/Scene/Loading/View/LoadingViewController.swift
+++ b/FitMate/FitMate/Scene/Loading/View/LoadingViewController.swift
@@ -27,7 +27,6 @@ class LoadingViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.view = loadingView
-        bindViewModel() // ViewModel 바인딩
     }
     
     // 네비게이션 영역 숨김

--- a/FitMate/FitMate/Scene/Loading/View/LoadingViewController.swift
+++ b/FitMate/FitMate/Scene/Loading/View/LoadingViewController.swift
@@ -11,10 +11,11 @@ import RxSwift
 
 class LoadingViewController: BaseViewController {
     
-    let viewModel: LoadingViewModel
-    private let loadingView = LoadingView()
+    private let viewModel: LoadingViewModel // ViewModel 의존성 주입
+    private let loadingView = LoadingView() // 뷰 객체 생성
     
     init(matchCode: String) {
+        // ViewModel 의존성 주입을 통해 운동 경기 코드를 전달
         self.viewModel = LoadingViewModel(matchCode: matchCode)
         super.init(nibName: nil, bundle: nil)
     }
@@ -26,6 +27,7 @@ class LoadingViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.view = loadingView
+        bindViewModel() // ViewModel 바인딩
     }
     
     // 네비게이션 영역 숨김
@@ -34,4 +36,37 @@ class LoadingViewController: BaseViewController {
         navigationController?.setNavigationBarHidden(true, animated: false)
     }
     
+    /// ViewModel 바인딩
+    override func bindViewModel() {
+        super.bindViewModel()
+        viewModel.matchStatusEvent
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] status in
+                if status == "accepted" {
+                    self?.goToGameScreen()
+                } else if status == "rejected" {
+                    self?.presentRejectedAlert()
+                }
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    /// 게임 화면으로 이동하는 메서드
+    private func goToGameScreen() {
+        // 게임화면으로 push or present
+        self.navigationController?.pushViewController(RunningCoopViewController(goalText: "매칭 테스트 화면입니다!!"), animated: true)
+    }
+    
+    /// 운동 요청 거절 시, 띄워지는 알림창 메서드
+    private func presentRejectedAlert() {
+        let alert = UIAlertController(title: "매칭 실패", message: "상대가 거절했습니다.", preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "확인", style: .default) { _ in
+            self.navigationController?.popToRootViewController(animated: true)
+        })
+        present(alert, animated: true)
+    }
+    
+    deinit {
+        print("LoadingViewController deinit")
+    }
 }

--- a/FitMate/FitMate/Scene/Loading/View/LoadingViewController.swift
+++ b/FitMate/FitMate/Scene/Loading/View/LoadingViewController.swift
@@ -7,10 +7,21 @@
 import UIKit
 import Lottie
 import SnapKit
+import RxSwift
 
 class LoadingViewController: BaseViewController {
     
-   private let loadingView = LoadingView()
+    let viewModel: LoadingViewModel
+    private let loadingView = LoadingView()
+    
+    init(matchCode: String) {
+        self.viewModel = LoadingViewModel(matchCode: matchCode)
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    @MainActor required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/FitMate/FitMate/Scene/Loading/ViewModel/LoadingViewModel.swift
+++ b/FitMate/FitMate/Scene/Loading/ViewModel/LoadingViewModel.swift
@@ -1,6 +1,8 @@
 //
+//  LoadingViewModel.swift
 //  FitMate
 //
-//  Created by 강성훈 on 6/5/25.
+//  Created by NH on 6/16/25.
 //
 
+import Foundation

--- a/FitMate/FitMate/Scene/Loading/ViewModel/LoadingViewModel.swift
+++ b/FitMate/FitMate/Scene/Loading/ViewModel/LoadingViewModel.swift
@@ -5,4 +5,36 @@
 //  Created by NH on 6/16/25.
 //
 
-import Foundation
+import RxSwift
+import RxRelay
+
+class LoadingViewModel {
+    // 화면으로 상태 이벤트 전달
+    let matchStatusEvent = PublishRelay<String>() // accepted, rejected 등
+    
+    private let disposeBag = DisposeBag()
+    private let matchCode: String
+    
+    init(matchCode: String) {
+        self.matchCode = matchCode
+        print("matchCode : \(matchCode)")
+        bindMatchStatus()
+    }
+    
+    private func bindMatchStatus() {
+        MatchEventService.shared.listenMatchStatus(matchCode: matchCode)
+        MatchEventService.shared.matchStatusRelay
+            .filter { $0.matchCode == self.matchCode }
+            .map { $0.status }
+            .do(onNext: { status in
+                print("ViewModel: matchStatusRelay에서 \(status) 받음")
+            })
+            .bind(to: matchStatusEvent)
+            .disposed(by: disposeBag)
+    }
+    
+    deinit {
+        MatchEventService.shared.stopListening()
+        print("로딩 뷰모델 디인잇")
+    }
+}

--- a/FitMate/FitMate/Scene/Loading/ViewModel/MatchAcceptViewModel.swift
+++ b/FitMate/FitMate/Scene/Loading/ViewModel/MatchAcceptViewModel.swift
@@ -1,8 +1,0 @@
-//
-//  MatchAcceptViewModel.swift
-//  FitMate
-//
-//  Created by NH on 6/17/25.
-//
-
-import Foundation

--- a/FitMate/FitMate/Scene/Loading/ViewModel/MatchAcceptViewModel.swift
+++ b/FitMate/FitMate/Scene/Loading/ViewModel/MatchAcceptViewModel.swift
@@ -1,0 +1,8 @@
+//
+//  MatchAcceptViewModel.swift
+//  FitMate
+//
+//  Created by NH on 6/17/25.
+//
+
+import Foundation

--- a/FitMate/FitMate/Scene/Login/View/LoginViewController.swift
+++ b/FitMate/FitMate/Scene/Login/View/LoginViewController.swift
@@ -49,13 +49,16 @@ class LoginViewController: BaseViewController {
         
         output.navigation
             .drive(onNext: { [weak self] nav in
+                guard let self else { return }
                 // ViewModel에서 전달한 목적에 따라 화면 이동만 수행
                 switch nav {
                 case .goToMainViewController(let uid):
+                    print("로그인 유져 UID : \(uid)")
+
                     // SceneDelegate를 가져오기
                     // UIApplication.shared.connectedScenes는 현재 앱의 모든 Scene을 반환
                     // first?.delegate는 첫 번째 Scene의 delegate를 가져옴
-                    //as? SceneDelegate로 다운캐스팅하여 window 속성에 접근
+                    // as? SceneDelegate로 다운캐스팅하여 window 속성에 접근
                     guard let sceneDelegate = UIApplication.shared.connectedScenes
                         .first?.delegate as? SceneDelegate else { return }
                     
@@ -74,9 +77,11 @@ class LoginViewController: BaseViewController {
                     })
                 case .error(let msg):
                     // 에러 발생 시 메시지 띄우기
-                    self?.showErrorAlert(message: msg)
+                    self.showErrorAlert(message: msg)
                 }
             }).disposed(by: disposeBag)
+        
+        
     }
     
     func showErrorAlert(message: String) {

--- a/FitMate/FitMate/Scene/Login/ViewModel/LoginViewModel.swift
+++ b/FitMate/FitMate/Scene/Login/ViewModel/LoginViewModel.swift
@@ -46,7 +46,7 @@ final class LoginViewModel {
                     return FirestoreService.shared
                         .fetchDocument(collectionName: "users", documentName: uid) // 사용자 문서 검색
                         .flatMap { data -> Single<LoginNavigation> in
-                            return .just(.goToMainViewController(uid: uid)) // 사용자 문서가 존재하면 .just(.goToSeleteSport(uid: uid)로 반환
+                            return .just(.goToMainViewController(uid: uid)) // 사용자 문서가 존재하면 .just(.goToSeleteSport(uid: uid))로 반환
                         }
                         .catch { _ in // 사용자 문서가 존재하지 않다면
                             return FirestoreService.shared

--- a/FitMate/FitMate/Scene/Main/View/MainViewController.swift
+++ b/FitMate/FitMate/Scene/Main/View/MainViewController.swift
@@ -10,6 +10,13 @@ import RxCocoa
 
 class MainViewController: BaseViewController {
     
+    // ViewModel 객체 생성
+    private let viewModel = MainViewModel()
+    
+    // MatchAcceptViewModel 객체 생성
+    // 역할 : 운동 경기 수락 여부에 따른 운동 경기 상태(matchStatus) 변경 ViewModel
+    private let matchAcceptViewModel = MatchAcceptViewModel()
+    
     private let mainView = MainView()
     
     // 로그인 유저의 uid

--- a/FitMate/FitMate/Scene/Main/View/MainViewController.swift
+++ b/FitMate/FitMate/Scene/Main/View/MainViewController.swift
@@ -49,5 +49,42 @@ class MainViewController: BaseViewController {
                 self.navigationController?.pushViewController(SportsSelectionViewController(uid: self.uid), animated: true)
             })
             .disposed(by: disposeBag)
+        
+        // 운동 초대 감지
+        viewModel.matchEvent
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] matchCode in
+                self?.presentAlertForMatch(matchCode: matchCode)
+                
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    /// 운동 초대 알림창 띄우는 메서드
+    func presentAlertForMatch(matchCode: String) {
+        let alert = UIAlertController(
+            title: "운동 메이트 요청",
+            message: "운동 초대가 도착했습니다!",
+            preferredStyle: .alert
+        )
+        // 수락
+        alert.addAction(UIAlertAction(title: "수락", style: .default, handler: { [weak self] _ in
+            guard let self else { return }
+            // 수락한 결과를 뷰모델에 보냄
+            // matchStatus 값이 accepted 로 변경됨
+            self.matchAcceptViewModel.respondToMatch(matchCode: matchCode, myUid: self.uid, accept: true)
+            
+            // 게임화면으로 이동
+            // 아직 테스트용으로 구현됨
+            self.navigationController?.pushViewController(RunningCoopViewController(goalText: "매칭 테스트 화면입니다!!"), animated: true)
+        }))
+        // 거절
+        alert.addAction(UIAlertAction(title: "거절", style: .destructive, handler: { [weak self] _ in
+            guard let self else { return }
+            // 거절한 결과를 뷰모델에 보냄
+            // matchStatus 값이 rejected 로 변경됨
+            self.matchAcceptViewModel.respondToMatch(matchCode: matchCode, myUid: self.uid, accept: false)
+        }))
+        present(alert, animated: true)
     }
 }

--- a/FitMate/FitMate/Scene/Main/ViewModel/MainViewModel.swift
+++ b/FitMate/FitMate/Scene/Main/ViewModel/MainViewModel.swift
@@ -1,6 +1,8 @@
 //
+//  MainViewModel.swift
 //  FitMate
 //
-//  Created by 강성훈 on 6/5/25.
+//  Created by NH on 6/16/25.
 //
 
+import Foundation

--- a/FitMate/FitMate/Scene/Main/ViewModel/MainViewModel.swift
+++ b/FitMate/FitMate/Scene/Main/ViewModel/MainViewModel.swift
@@ -5,4 +5,18 @@
 //  Created by NH on 6/16/25.
 //
 
-import Foundation
+import RxSwift
+import RxRelay
+
+class MainViewModel {
+    // 외부에서 observe할 수 있게 Observable로 노출
+    let matchEvent: Observable<String>
+    
+    private let disposeBag = DisposeBag()
+    
+    init() {
+        // 운동 초대 감지
+        // MatchEventService의 Relay를 그대로 연결
+        self.matchEvent = MatchEventService.shared.matchEventRelay.asObservable()
+    }
+}

--- a/FitMate/FitMate/Scene/Main/ViewModel/MatchAcceptViewModel.swift
+++ b/FitMate/FitMate/Scene/Main/ViewModel/MatchAcceptViewModel.swift
@@ -1,0 +1,20 @@
+//
+//  MatchAcceptViewModel.swift
+//  FitMate
+//
+//  Created by NH on 6/17/25.
+//
+
+import Foundation
+import FirebaseFirestore
+
+class MatchAcceptViewModel {
+    func respondToMatch(matchId: String, myUid: String, accept: Bool) {
+        let db = Firestore.firestore()
+        let newStatus = accept ? "accepted" : "rejected"
+        db.collection("matches").document(matchId).updateData([
+            "matchStatus": newStatus,
+            "players.\(myUid).status": newStatus
+        ])
+    }
+}

--- a/FitMate/FitMate/Scene/Main/ViewModel/MatchAcceptViewModel.swift
+++ b/FitMate/FitMate/Scene/Main/ViewModel/MatchAcceptViewModel.swift
@@ -8,11 +8,15 @@
 import Foundation
 import FirebaseFirestore
 
-class MatchAcceptViewModel {
-    func respondToMatch(matchId: String, myUid: String, accept: Bool) {
+final class MatchAcceptViewModel {
+    
+    /// 초대 응답 결과에 따른 Firestore의 운동 경기 상태 값 업데이트
+    func respondToMatch(matchCode: String, myUid: String, accept: Bool) {
         let db = Firestore.firestore()
+        
+        // 매개변수 accept 참, 거짓 여부에 따라 matchStatus 값 결정
         let newStatus = accept ? "accepted" : "rejected"
-        db.collection("matches").document(matchId).updateData([
+        db.collection("matches").document(matchCode).updateData([
             "matchStatus": newStatus,
             "players.\(myUid).status": newStatus
         ])

--- a/FitMate/FitMate/Scene/Running/RunningCoop/View/RunningCoopViewController.swift
+++ b/FitMate/FitMate/Scene/Running/RunningCoop/View/RunningCoopViewController.swift
@@ -27,6 +27,12 @@ class RunningCoopViewController: BaseViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
+    // 네비게이션 영역 숨김
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(true, animated: false)
+    }
+    
     // 뷰를 rootView로 설정
     override func loadView() {
         self.view = rootView

--- a/FitMate/FitMate/Scene/TabBar/TabBarController.swift
+++ b/FitMate/FitMate/Scene/TabBar/TabBarController.swift
@@ -27,6 +27,14 @@ class TabBarController: UITabBarController {
         configureTabBar()
         setUp()
         selectedIndex = 1 // 시작화면을 메인뷰로 시작
+        
+        // 운동 매칭 글로벌 리스너 서비스 시작
+        MatchEventService.shared.startListening(for: uid)
+    }
+    
+    deinit {
+        // 운동 매칭 글로벌 리스너 서비스 중지
+        MatchEventService.shared.stopListening()
     }
     
     private func configureTabBar() {


### PR DESCRIPTION
close #80 
<!-- close #No(이슈 넘버 등록하면 자동으로 이슈가 닫힙니다. 이슈를 닫고 싶지 않다면, 즉 해당 이슈의 작업이 아직 끝나지 않았다면 닫지 않습니다.) -->

## *⛳️ Work Description*

<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

### 실시간 전역 Firestore 감지 리스너 구현
- TabBarController 에 운동 매칭 글로벌 리스너 서비스 기능 구현
- 하위 VC에서 운동 생성 감지 가능

### 운동 생성 시, 메이트에게 초대 알림창 띄우기 기능 구현
- 리스너를 사용하여, Firestore에 저장된 경기 코드와 경기 상태 값을 감시
- 운동 생성 시, 메이트에게 초대 알림창이 띄워짐   

### 운동 초대 알림창 분기 처리
- 메이트는 운동 초대를 받으면 수락, 거절을 선택 가능
- 수락 : 게임 화면으로 이동됨 (아직 테스트용으로 이동됨)
- 거절 : 자신의 메이트(운동 생성자) 에게 거절되었다는 알림창이 띄워짐   

## *📸 Screenshot*

<!-- 구현한 부분의 시뮬레이터 스크린샷을 올려주시면 됩니다. -->
<!-- 기기대응을 위해 사이즈가 다른 기기별로 스크린샷을 올리기도 합니다. -->
<!-- 움직이는 동작일 경우, 시뮬레이터 영상을 녹화하고 gif로 저장하여 드래그 앤 드롭을 통해 업로드하면 됩니다. -->

### 초대 요청 거절 (메이트)
![Simulator Screen Recording - iPhone 16 Pro - 2025-06-17 at 02 48 11](https://github.com/user-attachments/assets/caf75572-edf8-43e1-8056-42e844f4313f)

### 요청 거절 결과 (운동 만든 유저)
![Simulator Screen Recording - iPhone 16 Pro - 2025-06-17 at 02 47 41](https://github.com/user-attachments/assets/6c9b9381-cc69-433d-abea-0f89fbddb149)

### 초대 요청 수락 (메이트)
![Simulator Screen Recording - iPhone 16 Pro - 2025-06-17 at 02 47 21](https://github.com/user-attachments/assets/7ee55abe-46e9-48ba-a952-b7566c301c09)

### 요청 수락 결과 (운동 만든 유저)
![Simulator Screen Recording - iPhone 16 Pro - 2025-06-17 at 02 47 00](https://github.com/user-attachments/assets/f345d83c-5317-42d6-9031-c8faae4a1aee)


## *📢 To Reviewers*

<!-- 이 PR을 리뷰하는 사람들에게 할 말이 있다면 작성하시면 됩니다. -->

- 현재 운동 생성 시, 실시간 감지로 초대 알림과, 응답에 대한 분기처리만 진행하였습니다.
- 그 외에는 테스트 용으로 기능이 제대로 구현이 되지 않았습니다. 

## *✅ Checklist*

<!-- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다. -->

- [x]  주석 및 프린트문 제거 확인.
- [x]  컨벤션 준수 확인.