### PR TITLE
[Feat] #82 닉네임 입력 기능 구현

### DIFF
--- a/FitMate/FitMate/App/SceneDelegate.swift
+++ b/FitMate/FitMate/App/SceneDelegate.swift
@@ -16,7 +16,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
 
         let window = UIWindow(windowScene: windowScene)
-        window.rootViewController = LoginViewController()
+        window.rootViewController = UINavigationController(rootViewController: LoginViewController()) 
         window.makeKeyAndVisible()
         self.window = window
     }

--- a/FitMate/FitMate/Common/Service/Firebase/Firestore/FirestoreService.swift
+++ b/FitMate/FitMate/Common/Service/Firebase/Firestore/FirestoreService.swift
@@ -220,6 +220,23 @@ class FirestoreService {
         }
     }
     
+    /// 닉네임 중복 여부 검사
+    func nicknameCheck(nickname: String) -> Single<Bool> {
+        return Single<Bool>.create { single in
+            self.db.collection("user")
+                .whereField("nickname", isEqualTo: nickname)
+                .getDocuments { snapshot, error in
+                    if let error = error {
+                        single(.failure(error))
+                    } else {
+                        let isExist = (snapshot?.documents.count ?? 0) > 0
+                        single(.success(isExist))
+                    }
+                }
+            return Disposables.create()
+        }
+    }
+    
     // MARK: - Update
     
     func updateDocument(collectionName: String, documentName: String, fields: [String: Any]) -> Single<Void> {

--- a/FitMate/FitMate/Scene/CodeShare/View/CodeShareViewController.swift
+++ b/FitMate/FitMate/Scene/CodeShare/View/CodeShareViewController.swift
@@ -12,7 +12,18 @@ import RxCocoa
 class CodeShareVIewController: BaseViewController {
 
     private let codeShareView = CodeShareView()
-
+    
+    private let uid: String // 로그인 사용자 uid
+    
+    init(uid: String) {
+        self.uid = uid // 의존성 주입
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    @MainActor required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     override func loadView() {
         self.view = codeShareView
     }

--- a/FitMate/FitMate/Scene/Login/View/LoginViewController.swift
+++ b/FitMate/FitMate/Scene/Login/View/LoginViewController.swift
@@ -22,6 +22,12 @@ class LoginViewController: BaseViewController {
         self.view = logInView
     }
     
+    // 네비게이션 영역 숨김
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(true, animated: false)
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         bindButton()
@@ -72,6 +78,31 @@ class LoginViewController: BaseViewController {
                                       animations: {
                         sceneDelegate.window?.rootViewController = tabBarController
                     })
+                case .goToInputMateCode(let uid):
+                    // 닉네임만 있음, 메이트 없음 → 메이트코드 입력
+                    let vc = CodeShareVIewController(uid: uid)
+                    self?.navigationController?.pushViewController(vc, animated: true)
+                case .goToInputNickName(let uid):
+                    // 닉네임이 없음 → 닉네임 입력
+                    let vc = NicknameViewController(uid: uid)
+                    self?.navigationController?.pushViewController(vc, animated: true)
+                    
+//                    guard let sceneDelegate = UIApplication.shared.connectedScenes
+//                        .first?.delegate as? SceneDelegate else { return }
+//                    
+//                    // 로그인 이후 메인으로 쓸 TabBarController 생성
+//                    let tabBarController = NicknameViewController(uid: uid) // 로그인 후 메인화면
+//                    
+//                    // SceneDelegate 의 window 없는지 확인
+//                    guard let window = sceneDelegate.window else { return }
+//                    
+//                    // 화면 전환
+//                    UIView.transition(with: window,
+//                                      duration: 0.5,
+//                                      options: .transitionCrossDissolve,
+//                                      animations: {
+//                        sceneDelegate.window?.rootViewController = tabBarController
+//                    })
                 case .error(let msg):
                     // 에러 발생 시 메시지 띄우기
                     self?.showErrorAlert(message: msg)

--- a/FitMate/FitMate/Scene/Login/View/NicknameRegisterView.swift
+++ b/FitMate/FitMate/Scene/Login/View/NicknameRegisterView.swift
@@ -84,7 +84,8 @@ class NicknameView: UIView {
     
     private func setupLayout() {
         nicknameViewTitle.snp.makeConstraints { make in
-            make.top.equalTo(safeAreaLayoutGuide).inset(-23)
+//            make.top.equalTo(safeAreaLayoutGuide).inset(-23)
+            make.top.equalTo(safeAreaLayoutGuide).inset(0)
             make.centerX.equalToSuperview()
         }
         

--- a/FitMate/FitMate/Scene/Login/View/NicknameRegisterView.swift
+++ b/FitMate/FitMate/Scene/Login/View/NicknameRegisterView.swift
@@ -21,6 +21,8 @@ class NicknameView: UIView {
     let nicknameHeader = CustomHeaderLabel(text: "닉네임")
     let nicknameField = CustomTextField(placeholder: "닉네임을 입력해주세요")
     
+    let validationMessageLabel = UILabel() // 유효성 검사 결과 출력 라벨
+    
     lazy var termsStack: UIStackView = {
         let image = UIImageView(image: UIImage(named: "check_1x"))
         image.contentMode = .scaleAspectFit
@@ -78,8 +80,12 @@ class NicknameView: UIView {
     }
 
     private func setupUI() {
-        [nicknameViewTitle, nicknameHeader, nicknameField,
+        [nicknameViewTitle, nicknameHeader, nicknameField, validationMessageLabel,
          termsStack, privacyStack, registerButton].forEach { addSubview($0) }
+        
+        validationMessageLabel.text = "테스트입니다."
+        validationMessageLabel.textColor = .white
+        validationMessageLabel.font = .systemFont(ofSize: 14, weight: .regular)
     }
     
     private func setupLayout() {
@@ -100,8 +106,13 @@ class NicknameView: UIView {
             make.height.equalTo(60)
         }
         
+        validationMessageLabel.snp.makeConstraints { make in
+            make.top.equalTo(nicknameField.snp.bottom).offset(14)
+            make.leading.equalToSuperview().inset(20)
+        }
+        
         termsStack.snp.makeConstraints { make in
-            make.top.equalTo(nicknameField.snp.bottom).offset(20)
+            make.top.equalTo(validationMessageLabel.snp.bottom).offset(20)
             make.leading.equalToSuperview().inset(20)
         }
         

--- a/FitMate/FitMate/Scene/Login/View/NicknameViewController.swift
+++ b/FitMate/FitMate/Scene/Login/View/NicknameViewController.swift
@@ -10,7 +10,8 @@ import RxSwift
 import RxCocoa
 
 class NicknameViewController: BaseViewController {
-
+    private let viewModel = NicknameViewModel() // 뷰모델
+    
     private let nicknameView = NicknameView()
     
     private let uid: String // 로그인 사용자 uid
@@ -35,16 +36,55 @@ class NicknameViewController: BaseViewController {
     }
 
     override func bindViewModel() {
-        nicknameView.registerButton.rx.tap
-            .asDriver(onErrorDriveWith: .empty())
-            .drive(onNext: { [weak self] _ in
-                guard let self else { return }
-                let codeShareView = CodeShareVIewController(uid: self.uid)
-                self.navigationController?.pushViewController(
-                    codeShareView, animated: true)
-            })
+//        nicknameView.registerButton.rx.tap
+//            .asDriver(onErrorDriveWith: .empty())
+//            .drive(onNext: { [weak self] _ in
+//                guard let self else { return }
+//                let codeShareView = CodeShareVIewController(uid: self.uid)
+//                self.navigationController?.pushViewController(
+//                    codeShareView, animated: true)
+//            })
+//            .disposed(by: disposeBag)
+        
+        // MARK: input output
+        let input = NicknameViewModel.Input(
+            nicknameText: nicknameView.nicknameField.rx.text.asObservable(),
+            nextButtonTap: nicknameView.registerButton.rx.tap.asObservable(),
+            uid: self.uid
+        )
+        
+        let output = viewModel.transform(input: input)
+        
+        // 유효성 메시지 라벨 바인딩 (Driver → .drive)
+        output.validationMessage
+            .drive(nicknameView.validationMessageLabel.rx.text)
             .disposed(by: disposeBag)
+        
+        // 닉네임 유효성 여부에 따라 다음 버튼 활성/비활성
+        output.isValidNickname
+            .drive(nicknameView.registerButton.rx.isEnabled)
+            .disposed(by: disposeBag)
+        
+        // 화면 이동
+        output.step
+            .drive(onNext: { [weak self] step in
+                guard let self else { return }
+                switch step {
+                case .goNext:
+                    let nextVC = CodeShareVIewController(uid: self.uid)
+                    self.navigationController?.pushViewController(nextVC, animated: true)
+                case .error(let message):
+                    self.showErrorToast(message: message)
+                case .none:
+                    break
+                }
+            }).disposed(by: disposeBag)
     }
 
+    func showErrorToast(message: String) {
+        let alert = UIAlertController(title: "닉네임 등록 실패", message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "확인", style: .default))
+        present(alert, animated: true)
+    }
 
 }

--- a/FitMate/FitMate/Scene/Login/View/NicknameViewController.swift
+++ b/FitMate/FitMate/Scene/Login/View/NicknameViewController.swift
@@ -12,17 +12,35 @@ import RxCocoa
 class NicknameViewController: BaseViewController {
 
     private let nicknameView = NicknameView()
+    
+    private let uid: String // 로그인 사용자 uid
+    
+    init(uid: String) {
+        self.uid = uid // 의존성 주입
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    @MainActor required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     override func loadView() {
         self.view = nicknameView
+    }
+    
+    // 네비게이션 영역 숨김
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(true, animated: false)
     }
 
     override func bindViewModel() {
         nicknameView.registerButton.rx.tap
             .asDriver(onErrorDriveWith: .empty())
             .drive(onNext: { [weak self] _ in
-                let codeShareView = CodeShareVIewController()
-                self?.navigationController?.pushViewController(
+                guard let self else { return }
+                let codeShareView = CodeShareVIewController(uid: self.uid)
+                self.navigationController?.pushViewController(
                     codeShareView, animated: true)
             })
             .disposed(by: disposeBag)

--- a/FitMate/FitMate/Scene/Login/ViewModel/LoginViewModel.swift
+++ b/FitMate/FitMate/Scene/Login/ViewModel/LoginViewModel.swift
@@ -14,7 +14,9 @@ final class LoginViewModel {
     
     // 화면 이동 목적을 나타내는 enum (분기 판단용)
     enum LoginNavigation {
-        case goToMainViewController(uid: String) // 레디룸으로 이동
+        case goToMainViewController(uid: String) // 메인 뷰로 이동
+        case goToInputMateCode(uid: String)     // 메이트 코드 입력 화면으로 이동
+        case goToInputNickName(uid: String)     // 닉네임 입력 화면으로 이동
         case error(String) // 에러 발생 (메시지 전달)
     }
 
@@ -46,12 +48,26 @@ final class LoginViewModel {
                     return FirestoreService.shared
                         .fetchDocument(collectionName: "users", documentName: uid) // 사용자 문서 검색
                         .flatMap { data -> Single<LoginNavigation> in
-                            return .just(.goToMainViewController(uid: uid)) // 사용자 문서가 존재하면 .just(.goToSeleteSport(uid: uid)로 반환
+                            // 닉네임이 있고
+                            if let nickname = data["nickname"] as? String,
+                               !nickname.isEmpty {
+                                // 메이트가 있으면
+                                if let mate = data["mate"] as? String, !mate.isEmpty {
+                                    // 메인 뷰로 이동
+                                    return .just(.goToMainViewController(uid: uid))
+                                } else {
+                                    // 메이트가 없으면 메이트 등록 화면으로 이동
+                                    return .just(.goToInputMateCode(uid: uid))
+                                }
+                            } else {
+                                // 닉네임이 없으면 닉네임 입력 화면으로 이동
+                                return .just(.goToInputNickName(uid: uid))
+                            }
                         }
                         .catch { _ in // 사용자 문서가 존재하지 않다면
                             return FirestoreService.shared
                                 .createUserDocument(uid: uid) // 사용자 uid 로 문서를 생성
-                                .map { .goToMainViewController(uid: uid) } // .just(.goToSeleteSport(uid: uid)로 반환
+                                .map { .goToInputNickName(uid: uid) } // .just(.goToInputNickName(uid: uid)로 반환
                         }
                         .asObservable()
 

--- a/FitMate/FitMate/Scene/Login/ViewModel/NicknameViewModel.swift
+++ b/FitMate/FitMate/Scene/Login/ViewModel/NicknameViewModel.swift
@@ -1,0 +1,109 @@
+//
+//  NicknameViewModel.swift
+//  FitMate
+//
+//  Created by NH on 6/17/25.
+//
+
+import Foundation
+import RxSwift
+import RxCocoa
+
+enum NicknameNavigation {
+    case none // 아무 상태도 아님(초기 상태)
+    case goNext(uid: String) // 다음 화면으로 이동해야 할 때
+    case error(String) // 에러(메시지와 함께)
+}
+
+final class NicknameViewModel {
+    struct Input {
+        let nicknameText: Observable<String?> // 닉네임 입력 텍스트
+        let nextButtonTap: Observable<Void>   // 다음 버튼 클릭 이벤트
+        let uid: String                       // 사용자 고유 id (필수)
+    }
+    
+    struct Output {
+        let validationMessage: Driver<String>    // 유효성 메시지 출력용
+        let isValidNickname: Driver<Bool>        // 닉네임 사용 가능 여부
+        let step: Driver<NicknameNavigation>           // 다음 화면 이동 등 상태 신호
+    }
+    
+    // 내부적으로 유효성 메시지/상태를 관리하는 Relay
+    private let validationMessageRelay = BehaviorRelay<String>(value: "")
+    private let isValidNicknameRelay = BehaviorRelay<Bool>(value: false)
+    private let stepRelay = PublishRelay<NicknameNavigation>()
+    
+    private let disposeBag = DisposeBag()
+    
+    func transform(input: Input) -> Output {
+        // 닉네임 텍스트 입력 스트림 (nil 제거, 중복 입력 방지, 최신 값만 유지)
+        let nicknameText = input.nicknameText
+            .compactMap { $0 }
+            .distinctUntilChanged()
+            .share(replay: 1, scope: .whileConnected)
+        
+        // 닉네임 입력시마다 유효성 검사 (2~6글자 & Firestore 중복 검사)
+        nicknameText
+            .flatMapLatest { text -> Observable<(Bool, String)> in
+                if text.count < 2 {
+                    return .just((false, "닉네임은 2글자 이상이여야 됩니다."))
+                } else if text.count > 6 {
+                    return .just((false, "닉네임이 6글자를 넘어갔습니다."))
+                } else {
+                    // Firestore에서 중복 닉네임 체크
+                    return FirestoreService.shared.nicknameCheck(nickname: text)
+                        .map { isExist in
+                            if isExist {
+                                return (false, "이미 존재하는 닉네임입니다.")
+                            } else {
+                                return (true, "사용 가능한 닉네임입니다.")
+                            }
+                        }
+                        .asObservable()
+                }
+            }
+        // 결과를 BehaviorRelay에 반영 (메시지/유효성 여부 업데이트)
+            .subscribe(onNext: { [weak self] isValid, message in
+                self?.isValidNicknameRelay.accept(isValid)
+                self?.validationMessageRelay.accept(message)
+            })
+            .disposed(by: disposeBag)
+        
+        // "다음" 버튼 탭 시 → 유효성 통과한 닉네임만 처리
+        input.nextButtonTap
+        // 최신 유효성 및 닉네임 값을 함께 가져옴
+            .withLatestFrom(Observable.combineLatest(isValidNicknameRelay, nicknameText))
+        // 유효성 OK인 경우만 통과
+            .filter { isValid, _ in isValid }
+            .map { _, nickname in nickname }
+        // 닉네임 저장 및 "이동 신호" 방출
+            .subscribe(onNext: { [weak self] nickname in
+                guard let self else { return }
+                guard !input.uid.isEmpty else {
+                    // uid가 비어 있으면 에러 신호 방출
+                    self.stepRelay.accept(.error("uid가 비어있습니다"))
+                    return
+                }
+                               
+                FirestoreService.shared.updateDocument(collectionName: "users", documentName: input.uid, fields: ["nickname": nickname])
+                    .subscribe(
+                        onSuccess: {
+                            print("닉네임 등록 성공")
+                        },
+                        onFailure: { error in
+                            print("실패 \(error.localizedDescription)")
+                        }
+                    ).disposed(by: self.disposeBag)
+                
+                // 저장 완료 후 다음 화면 이동 신호
+                self.stepRelay.accept(.goNext(uid: input.uid))
+            }).disposed(by: disposeBag)
+        
+        // Output: 뷰에서 구독할 수 있도록 내보냄
+        return Output(
+            validationMessage: validationMessageRelay.asDriver(), // 메시지 라벨용
+            isValidNickname: isValidNicknameRelay.asDriver(),     // 필요시 버튼 활성화 등
+            step: stepRelay.asDriver(onErrorJustReturn: .error("알 수 없는 오류")) // 화면 이동 등 상태 신호
+        )
+    }
+}


### PR DESCRIPTION
close #82 
<!-- close #No(이슈 넘버 등록하면 자동으로 이슈가 닫힙니다. 이슈를 닫고 싶지 않다면, 즉 해당 이슈의 작업이 아직 끝나지 않았다면 닫지 않습니다.) -->

## *⛳️ Work Description*

<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- 사용자가 로그인 시, 닉네임이 없으면 닉네임 입력 화면으로 이동
- 닉네임 입력 화면에서 닉네임 입력 후 등록 완료 버튼 탭 시, Firestore 유저 DB에 닉네임 저장됨.
- 닉네임은 현재 2~6글자 그리고 중복 여부만 체크함.
- 영문,숫자,한글 제한 기능도 추가해야됨  

## *📸 Screenshot*

<!-- 구현한 부분의 시뮬레이터 스크린샷을 올려주시면 됩니다. -->
<!-- 기기대응을 위해 사이즈가 다른 기기별로 스크린샷을 올리기도 합니다. -->
<!-- 움직이는 동작일 경우, 시뮬레이터 영상을 녹화하고 gif로 저장하여 드래그 앤 드롭을 통해 업로드하면 됩니다. -->
### 앱 화면
![Simulator Screen Recording - iPhone 16 Pro - 2025-06-17 at 04 23 13](https://github.com/user-attachments/assets/75f76d7f-ba76-41e9-a0b1-57b89a9df2a8)
### Firestore DB 내용
<img width="1444" alt="image" src="https://github.com/user-attachments/assets/d6406e7a-8adb-4269-8baa-f23d98ac6ddc" />

## *📢 To Reviewers*

<!-- 이 PR을 리뷰하는 사람들에게 할 말이 있다면 작성하시면 됩니다. -->

- 코드리뷰 부탁드립니다.

## *✅ Checklist*

<!-- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다. -->

- [x]  주석 및 프린트문 제거 확인.
- [x]  컨벤션 준수 확인.