### PR TITLE
Design/#124 화면 전환, 약관버튼+닉네임 입력해야 버튼 활성화

### DIFF
--- a/FitMate/FitMate/Common/Components/CustomTextField.swift
+++ b/FitMate/FitMate/Common/Components/CustomTextField.swift
@@ -30,6 +30,7 @@ class CustomTextField: UITextField {
             attributes: [.foregroundColor: UIColor.lightGray] // 컬러 변경 필요
         )
         self.contentVerticalAlignment = .center
+        self.textColor = .white
         self.layer.cornerRadius = 4
         self.borderStyle = .line
         self.layer.borderColor = UIColor.systemPurple.cgColor // 컬러 변경 필요

--- a/FitMate/FitMate/Scene/CodeShare/View/CodeShareViewController.swift
+++ b/FitMate/FitMate/Scene/CodeShare/View/CodeShareViewController.swift
@@ -43,6 +43,12 @@ final class CodeShareViewController: BaseViewController {
         bind()
     }
     
+    // 시스템 네비게이션바 숨김
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(true, animated: false)
+    }
+    
     // MARK: - Binding
     
     /// ViewModel의 Input/Output을 구성하고 UI 이벤트에 바인딩

--- a/FitMate/FitMate/Scene/CodeShare/View/MateCodeView.swift
+++ b/FitMate/FitMate/Scene/CodeShare/View/MateCodeView.swift
@@ -54,7 +54,7 @@ class MateCodeView: BaseView {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        backgroundColor = .black
+        backgroundColor = .background800
         configureUI()
         setLayoutUI()
     }

--- a/FitMate/FitMate/Scene/Finish/View/FinishViewController.swift
+++ b/FitMate/FitMate/Scene/Finish/View/FinishViewController.swift
@@ -4,24 +4,24 @@ import RxCocoa
 
 // 운동 종료 결과를 보여주는 컨트롤러
 class FinishViewController: BaseViewController {
-
+    
     private let finishView = FinishView()
     private let viewModel: FinishViewModel
-
+    
     init(viewModel: FinishViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }
-
+    
     required init?(coder: NSCoder) { fatalError("not implemented") }
-
+    
     override func loadView() {
         self.view = finishView
     }
-
+    
     override func bindViewModel() {
         let output = viewModel.transform(input: .init())
-
+        
         output.modeText
             .drive(onNext: { [weak self] text in self?.finishView.updateMode(text) })
             .disposed(by: disposeBag)
@@ -67,4 +67,5 @@ class FinishViewController: BaseViewController {
                 }
             }
             .disposed(by: disposeBag)
+    }
 }

--- a/FitMate/FitMate/Scene/History/View/HistoryView.swift
+++ b/FitMate/FitMate/Scene/History/View/HistoryView.swift
@@ -45,7 +45,7 @@ final class HistoryView: UIView {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
-        backgroundColor = UIColor(named: "Background900")
+        backgroundColor = UIColor(named: "Background800")
 
         categoryCollectionView.register(CategoryCell.self, forCellWithReuseIdentifier: CategoryCell.identifier)
         recordCollectionView.register(WalkRecordCell.self, forCellWithReuseIdentifier: WalkRecordCell.identifier)

--- a/FitMate/FitMate/Scene/Main/View/HasNoMateViewController.swift
+++ b/FitMate/FitMate/Scene/Main/View/HasNoMateViewController.swift
@@ -81,17 +81,17 @@ class HasNoMateViewController: UIViewController {
     }
     
     @objc private func goToAddMate() {
-            let codeShareVC = CodeShareViewController(uid: self.uid, hasMate: false)
+        // 먼저 dismiss 전에 safe하게 저장해놓기
+        guard let presentingVC = self.presentingViewController else { return }
 
-            // 네비게이션 컨트롤러 래핑해서 모달 전체화면으로 present
+        dismiss(animated: true) {
+            let codeShareVC = CodeShareViewController(uid: self.uid, hasMate: false)
             let nav = UINavigationController(rootViewController: codeShareVC)
             nav.modalPresentationStyle = .fullScreen
             
-            // 현재 모달 닫고 새로운 네비게이션 흐름 시작
-            self.dismiss(animated: true) {
-                // presentingViewController 기준으로 present
-                self.presentingViewController?.present(nav, animated: true, completion: nil)
-            }
+            presentingVC.present(nav, animated: true)
+        }
     }
+
 
 }

--- a/FitMate/FitMate/Scene/Main/View/MainView.swift
+++ b/FitMate/FitMate/Scene/Main/View/MainView.swift
@@ -99,7 +99,7 @@ class MainView: BaseView {
     }
     
     override func configureUI() {
-        backgroundColor = .black
+        backgroundColor = .background800
         [topBar, explainLabel, dDaysLabel, myAvatarImage,
           mateAvatarImage, exerciseButton].forEach{ addSubview($0) }
         

--- a/FitMate/FitMate/Scene/Mypage/View/MatepageViewController.swift
+++ b/FitMate/FitMate/Scene/Mypage/View/MatepageViewController.swift
@@ -37,6 +37,7 @@ final class MatepageViewController: UIViewController, UICollectionViewDelegateFl
         bindViewModel()
 
         rootView.recordCollectionView.register(WorkRecordCell.self, forCellWithReuseIdentifier: WorkRecordCell.identifier)
+        setupActions()
     }
 
     private func bindViewModel() {
@@ -52,6 +53,14 @@ final class MatepageViewController: UIViewController, UICollectionViewDelegateFl
                 cellType: WorkRecordCell.self)
             ) { index, record, cell in
                 cell.configure(with: record)
+            }
+            .disposed(by: disposeBag)
+    }
+    
+    private func setupActions() {
+        rootView.backButton.rx.tap
+            .bind { [weak self] in
+                self?.navigationController?.popViewController(animated: true)
             }
             .disposed(by: disposeBag)
     }

--- a/FitMate/FitMate/Scene/Mypage/View/MypageView.swift
+++ b/FitMate/FitMate/Scene/Mypage/View/MypageView.swift
@@ -109,7 +109,7 @@ final class MypageView: UIView {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
-        backgroundColor = .black
+        backgroundColor = .background800
         setupLayout()
     }
 

--- a/FitMate/FitMate/Scene/Mypage/View/MypageView.swift
+++ b/FitMate/FitMate/Scene/Mypage/View/MypageView.swift
@@ -9,6 +9,13 @@ final class MypageView: UIView {
         button.tintColor = .white
         return button
     }()
+    
+    let backButton: UIButton = {
+        let back = UIButton()
+        back.setImage(UIImage(named: "backButton"), for: .normal)
+        back.contentHorizontalAlignment = .leading
+        return back
+    }()
 
     let topBar = UIView()
 
@@ -123,7 +130,8 @@ final class MypageView: UIView {
         addSubview(nicknameLabel)
         addSubview(underline)
         addSubview(contentLabel)
-
+        
+        topBar.addSubview(backButton)
         topBar.addSubview(titleLabel)
         topBar.addSubview(settingButton)
 
@@ -148,6 +156,12 @@ final class MypageView: UIView {
         settingButton.snp.makeConstraints {
             $0.centerY.equalToSuperview()
             $0.trailing.equalToSuperview().inset(20)
+            $0.width.height.equalTo(24)
+        }
+        
+        backButton.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalToSuperview().inset(20)
             $0.width.height.equalTo(24)
         }
 


### PR DESCRIPTION
close #124
<!-- close #No(이슈 넘버 등록하면 자동으로 이슈가 닫힙니다. 이슈를 닫고 싶지 않다면, 즉 해당 이슈의 작업이 아직 끝나지 않았다면 닫지 않습니다.) -->

## *⛳️ Work Description*

- 플레이스 홀더 색상 변경
- 마마이페이지 얼럿에서 뒤로 가기
- 텍스트 필드에 입력만 한다고 해서 뒤로 넘어가면 안됨 -> 닉네임 + 체크박스 둘다 완료되어야 버튼 활성화
- 메이트 페이지 백버튼넣고 화면전환

## *📸 Screenshot*

<img src="https://github.com/user-attachments/assets/df64a503-d0a4-4d49-b394-d20aec0f1340" width="50%">


## *📢 To Reviewers*

- 코드리뷰 부탁드립니다.

## *✅ Checklist*

<!-- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다. -->

- [x]  주석 및 프린트문 제거 확인.
- [x]  컨벤션 준수 확인.
