### PR TITLE
[Fix] #142 플랭크 숨김처리 및 실시간 운동공유화면 종목 타이틀 보이기

### DIFF
--- a/FitMate/FitMate/Scene/GoalSelection/ViewModel/GoalSelectionViewModel.swift
+++ b/FitMate/FitMate/Scene/GoalSelection/ViewModel/GoalSelectionViewModel.swift
@@ -16,7 +16,7 @@ class GoalSelectionViewModel: ViewModelType {
     }
     
     // 선택된 운동 제목을 저장하는 BehaviorRelay (초기값은 빈 문자열)
-    private let selectedGoalTitleRelay = BehaviorRelay<String>(value: "")
+    let selectedGoalTitleRelay = BehaviorRelay<String>(value: "")
     // 선택된 운동 모드를 저장
     private let selectedModeRelay = BehaviorRelay<SportsModeViewController.ExerciseMode>(value: .cooperation)
     

--- a/FitMate/FitMate/Scene/Running/RunningCoop/View/RunningCoopViewController.swift
+++ b/FitMate/FitMate/Scene/Running/RunningCoop/View/RunningCoopViewController.swift
@@ -19,6 +19,7 @@ final class RunningCoopViewController: BaseViewController {
     // 시작 트리거용(버튼, viewDidLoad 등에서 신호 보낼 때 사용)
     private let startRelay = PublishRelay<Void>()
     private let mateDistanceRelay = BehaviorRelay<Double>(value: 0)
+    private let goalselecionViewModel = GoalSelectionViewModel()
     
     private let matchCode: String
     private let mateUid: String
@@ -61,8 +62,8 @@ final class RunningCoopViewController: BaseViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        rootView.updateGoal("\(runningCoopViewModel.goalDistance)Km")
+        let goalTitle = goalselecionViewModel.selectedGoalTitleRelay.value
+        rootView.updateGoal("\(goalTitle) \(runningCoopViewModel.goalDistance)Km")
         rootView.updateMyCharacter(runningCoopViewModel.myCharacter)
         rootView.updateMateCharacter(runningCoopViewModel.mateCharacter)
         

--- a/FitMate/FitMate/Scene/SportsSelection/ViewModel/SportsSelectionViewModel.swift
+++ b/FitMate/FitMate/Scene/SportsSelection/ViewModel/SportsSelectionViewModel.swift
@@ -36,13 +36,13 @@ class CarouselViewModel: ViewModelType {
 
     // 실제 운동 아이템 원본 배열
     private let originalItemsSource: [ExerciseItem] = [
-        ExerciseItem(
-            image: UIImage(named: "plank") ?? UIImage(),
-            title: "플랭크",
-            calorie: "150kcal / 10분",
-            description: "정적인 코어 운동",
-            effect: "복부 근육 강화, 자세 안정"
-        ),
+//        ExerciseItem(
+//            image: UIImage(named: "plank") ?? UIImage(),
+//            title: "플랭크",
+//            calorie: "150kcal / 10분",
+//            description: "정적인 코어 운동",
+//            effect: "복부 근육 강화, 자세 안정"
+//        ),
         ExerciseItem(
             image: UIImage(named: "bicycle") ?? UIImage(),
             title: "자전거",


### PR DESCRIPTION
close #142
<!-- close #No(이슈 넘버 등록하면 자동으로 이슈가 닫힙니다. 이슈를 닫고 싶지 않다면, 즉 해당 이슈의 작업이 아직 끝나지 않았다면 닫지 않습니다.) -->

## *⛳️ Work Description*

- 플랭크 숨김처리 및 실시간 운동공유화면 종목 타이틀 보이기

## *📸 Screenshot*

- 저 친구 못 만드는 저주받은 계정이라 확인 할 수가 읎어요.

## *📢 To Reviewers*

-저 친구 못 만드는 저주받은 계정이라 확인 할 수가 읎어요. 타이틀 잘 들어오는지 확인점 해주십쇼 감사합니다.
- 코드리뷰 부탁드립니다.

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거 확인.
- [ ]  컨벤션 준수 확인.
