### PR TITLE
[Chore] #148 히스토리+마이페이지 플랭크관련 숨김처리 & 마이페이지 이미지 연결

### DIFF
--- a/FitMate/FitMate/Scene/History/View/HistoryView.swift
+++ b/FitMate/FitMate/Scene/History/View/HistoryView.swift
@@ -52,7 +52,7 @@ final class HistoryView: UIView {
         recordCollectionView.register(JumpRopeRecordCell.self, forCellWithReuseIdentifier: JumpRopeRecordCell.identifier)
         recordCollectionView.register(BicycleRecordCell.self, forCellWithReuseIdentifier: BicycleRecordCell.identifier)
         recordCollectionView.register(RunRecordCell.self, forCellWithReuseIdentifier: RunRecordCell.identifier)
-        recordCollectionView.register(PlankRecordCell.self, forCellWithReuseIdentifier: PlankRecordCell.identifier)
+        //recordCollectionView.register(PlankRecordCell.self, forCellWithReuseIdentifier: PlankRecordCell.identifier)
 
         setupLayout()
     }
@@ -69,7 +69,7 @@ final class HistoryView: UIView {
         addSubview(contentLabel)
         
         titleLabel.snp.makeConstraints {
-            $0.top.equalTo(safeAreaLayoutGuide.snp.top).offset(12)
+            $0.top.equalTo(safeAreaLayoutGuide.snp.top).offset(-10)
             $0.centerX.equalToSuperview()
         }
 

--- a/FitMate/FitMate/Scene/History/View/HistoryViewController.swift
+++ b/FitMate/FitMate/Scene/History/View/HistoryViewController.swift
@@ -46,7 +46,7 @@ final class HistoryViewController: UIViewController, UICollectionViewDelegateFlo
     }
 
     private func bindViewModel() {
-        Observable.just(ExerciseType.allCases)
+        Observable.just(ExerciseType.allCases.filter { $0 != .plank }) //플랭크 필터링
             .bind(to: rootView.categoryCollectionView.rx.items(
                 cellIdentifier: CategoryCell.identifier,
                 cellType: CategoryCell.self)
@@ -67,9 +67,8 @@ final class HistoryViewController: UIViewController, UICollectionViewDelegateFlo
 
         output.filteredRecords
             .drive(onNext: { [weak self] records in
-                print("✅ ViewController: reload 호출됨, \(records.count)건")
+                print(" ViewController: reload 호출됨, \(records.count)건")
                 self?.rootView.recordCollectionView.reloadData()
-                // ✅ 내용 유무에 따라 "기록이 없습니다" 문구 숨김 처리
                 self?.rootView.contentLabel.isHidden = !records.isEmpty
             })
             .disposed(by: disposeBag)
@@ -80,8 +79,8 @@ final class HistoryViewController: UIViewController, UICollectionViewDelegateFlo
             let width = collectionView.frame.width - 32
             return CGSize(width: width, height: 120)
         } else {
-            let width: CGFloat = floor(collectionView.frame.width / CGFloat(ExerciseType.allCases.count))
-            return CGSize(width: width, height: 40)
+            //let width: CGFloat = floor(collectionView.frame.width / CGFloat(ExerciseType.allCases.count))
+            return CGSize(width: 78.4 , height: 40)
         }
     }
 }
@@ -115,11 +114,11 @@ extension HistoryViewController: UICollectionViewDataSource {
             cell.configure(with: record)
             return cell
         
-        case .plank:
-            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PlankRecordCell.identifier, for: indexPath) as! PlankRecordCell
-            cell.configure(with: record)
-            return cell
-            
+        case .plank: //플랭크 핉러링으로 인한 주석처리
+//            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PlankRecordCell.identifier, for: indexPath) as! PlankRecordCell
+//            cell.configure(with: record)
+//            return cell
+            fallthrough
         default:
             fatalError("종목 없음")
         }

--- a/FitMate/FitMate/Scene/Mypage/View/Cell/WorkRecordCell.swift
+++ b/FitMate/FitMate/Scene/Mypage/View/Cell/WorkRecordCell.swift
@@ -1,4 +1,3 @@
-// WorkRecordCell.swift
 import UIKit
 import SnapKit
 
@@ -15,9 +14,17 @@ final class WorkRecordCell: UICollectionViewCell {
 
     private let characterImageView: UIView = {
         let view = UIView()
-        view.backgroundColor = .lightGray
+        view.backgroundColor = .white
         view.layer.cornerRadius = 4
+        view.clipsToBounds = true
         return view
+    }()
+
+    private let characterImage: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFit
+        imageView.clipsToBounds = true
+        return imageView
     }()
 
     private let typeLabel: UILabel = {
@@ -61,6 +68,13 @@ final class WorkRecordCell: UICollectionViewCell {
             $0.width.equalTo(335)
         }
 
+        characterImageView.addSubview(characterImage)
+        characterImage.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.width.equalTo(88)
+            $0.height.equalTo(88)
+        }
+
         let infoStack = UIStackView(arrangedSubviews: [typeLabel, totalLabel, unitLabel])
         infoStack.axis = .vertical
         infoStack.spacing = 4
@@ -85,5 +99,20 @@ final class WorkRecordCell: UICollectionViewCell {
         typeLabel.text = record.type
         totalLabel.text = record.totalDistance
         unitLabel.text = record.unit
+
+        switch record.type {
+        case "걷기":
+            characterImage.image = UIImage(named: "walk")
+        case "달리기":
+            characterImage.image = UIImage(named: "run")
+        case "자전거":
+            characterImage.image = UIImage(named: "bicycle")
+        case "줄넘기":
+            characterImage.image = UIImage(named: "jumpRope")
+        case "플랭크":
+            characterImage.image = UIImage(named: "plank")
+        default:
+            characterImage.image = nil
+        }
     }
 }

--- a/FitMate/FitMate/Scene/Mypage/View/MatepageViewController.swift
+++ b/FitMate/FitMate/Scene/Mypage/View/MatepageViewController.swift
@@ -1,4 +1,3 @@
-// MatepageViewController.swift
 import UIKit
 import RxSwift
 import RxCocoa
@@ -14,7 +13,11 @@ final class MatepageViewController: UIViewController, UICollectionViewDelegateFl
     init(mateUid: String) {
         self.mateUid = mateUid
         self.viewModel = MypageViewModel(uid: mateUid)
-        self.rootView = MypageView(showSettingButton: false, titleText: "메이트페이지")
+        self.rootView = MypageView(
+            showSettingButton: false,
+            titleText: "메이트페이지",
+            showBackButton: true
+        )
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -37,8 +40,12 @@ final class MatepageViewController: UIViewController, UICollectionViewDelegateFl
         rootView.recordCollectionView.delegate = self
         bindViewModel()
 
-        rootView.recordCollectionView.register(WorkRecordCell.self, forCellWithReuseIdentifier: WorkRecordCell.identifier)
-        setupActions()
+        rootView.recordCollectionView.register(
+            WorkRecordCell.self,
+            forCellWithReuseIdentifier: WorkRecordCell.identifier
+        )
+
+        setupBackButtonAction()
     }
 
     private func bindViewModel() {
@@ -57,8 +64,8 @@ final class MatepageViewController: UIViewController, UICollectionViewDelegateFl
             }
             .disposed(by: disposeBag)
     }
-    
-    private func setupActions() {
+
+    private func setupBackButtonAction() {
         rootView.backButton.rx.tap
             .bind { [weak self] in
                 self?.navigationController?.popViewController(animated: true)

--- a/FitMate/FitMate/Scene/Mypage/View/MypageView.swift
+++ b/FitMate/FitMate/Scene/Mypage/View/MypageView.swift
@@ -1,5 +1,3 @@
-// MypageView.swift
-
 import UIKit
 import SnapKit
 
@@ -13,10 +11,10 @@ final class MypageView: UIView {
     }()
     
     let backButton: UIButton = {
-        let back = UIButton()
-        back.setImage(UIImage(named: "backButton"), for: .normal)
-        back.contentHorizontalAlignment = .leading
-        return back
+        let button = UIButton()
+        button.setImage(UIImage(named: "backButton"), for: .normal)
+        button.contentHorizontalAlignment = .leading
+        return button
     }()
 
     let topBar = UIView()
@@ -29,11 +27,13 @@ final class MypageView: UIView {
         return label
     }()
 
-    let profileImageView: UIView = {
-        let view = UIView()
-        view.backgroundColor = .lightGray
-        view.layer.cornerRadius = 4
-        return view
+    let profileImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(named: "KappyAlone")
+        imageView.contentMode = .scaleAspectFit
+        imageView.backgroundColor = UIColor(named: "Secondary50")
+        imageView.layer.cornerRadius = 4
+        return imageView
     }()
 
     let nicknameLabel: UILabel = {
@@ -46,7 +46,7 @@ final class MypageView: UIView {
 
     private let underline: UIView = {
         let view = UIView()
-        view.backgroundColor = UIColor(red: 138/255, green: 43/255, blue: 226/255, alpha: 1)
+        view.backgroundColor = UIColor(named: "Primary500")
         return view
     }()
 
@@ -101,18 +101,20 @@ final class MypageView: UIView {
         collectionView.isScrollEnabled = false
         return collectionView
     }()
-    
+
     private let contentLabel: UILabel = {
-       let label = UILabel()
+        let label = UILabel()
         label.text = "기록이 없습니다"
         label.font = UIFont(name: "DungGeunMo", size: 20)
         label.textColor = .background500
         return label
     }()
 
-    convenience init(showSettingButton: Bool = true, titleText: String = "") {
+    // ✅ 백버튼 제어 가능한 이니셜라이저
+    convenience init(showSettingButton: Bool = true, titleText: String = "", showBackButton: Bool = true) {
         self.init(frame: .zero)
         settingButton.isHidden = !showSettingButton
+        backButton.isHidden = !showBackButton
         titleLabel.text = titleText
     }
 
@@ -131,11 +133,11 @@ final class MypageView: UIView {
         addSubview(profileImageView)
         addSubview(nicknameLabel)
         addSubview(underline)
-        addSubview(contentLabel)
-        
-        topBar.addSubview(backButton)
+        contentView.addSubview(contentLabel)
+
         topBar.addSubview(titleLabel)
         topBar.addSubview(settingButton)
+        topBar.addSubview(backButton) 
 
         addSubview(scrollView)
         scrollView.addSubview(contentView)
@@ -160,7 +162,7 @@ final class MypageView: UIView {
             $0.trailing.equalToSuperview().inset(20)
             $0.width.height.equalTo(24)
         }
-        
+
         backButton.snp.makeConstraints {
             $0.centerY.equalToSuperview()
             $0.leading.equalToSuperview().inset(20)
@@ -216,10 +218,10 @@ final class MypageView: UIView {
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(700)
         }
-        
-        contentLabel.snp.makeConstraints { make in
-            make.top.equalTo(levelTitle.snp.bottom).offset(100)
-            make.center.equalToSuperview()
+
+        contentLabel.snp.makeConstraints {
+            $0.top.equalTo(levelTitle.snp.bottom).offset(100)
+            $0.center.equalToSuperview()
         }
 
         achievementTitleStack.isHidden = true

--- a/FitMate/FitMate/Scene/Mypage/View/MypageViewController.swift
+++ b/FitMate/FitMate/Scene/Mypage/View/MypageViewController.swift
@@ -1,11 +1,10 @@
-// MypageViewController.swift
 import UIKit
 import RxSwift
 import RxCocoa
 
 final class MypageViewController: UIViewController, UICollectionViewDelegateFlowLayout {
 
-    private let rootView = MypageView(showSettingButton: true, titleText: "마이페이지")
+    private let rootView = MypageView(showSettingButton: true, titleText: "마이페이지", showBackButton: false)
     private let viewModel: MypageViewModel
     private let disposeBag = DisposeBag()
     

--- a/FitMate/FitMate/Scene/Mypage/ViewModel/MypageViewModel.swift
+++ b/FitMate/FitMate/Scene/Mypage/ViewModel/MypageViewModel.swift
@@ -35,6 +35,9 @@ final class MypageViewModel {
         
         let records = FirestoreService.shared
             .fetchTotalStats(uid: uid)
+            .map { records in
+                records.filter { $0.type != "플랭크" }  //플랭크 필터처리
+            }
             .do(onSuccess: { print("🏁 ViewModel에서 받은 기록: \($0)") })
             .asDriver(onErrorJustReturn: [])
         


### PR DESCRIPTION
close #148 

## *⛳️ Work Description*

1. 마이페이지/히스토리 UI 플랭크 관련 항목 숨김처리
  - 히스토리 카테고리에서 플랭크종목 숨김처리
  - 마이페이지 플랭크 기록카드 숨김처리

2. 마이페이지 이미지 추가
  - 프로필 이미지 "캐피" 등록
  - 각 기록카드에 운동 이미지 추가

3. 마이페이지 뒤로가기버튼 삭제

4. 메이트페이지 뒤로가기버튼 추가

## *📸 Screenshot*

![스크린샷 2025-06-20 오후 10 06 27](https://github.com/user-attachments/assets/b9a02e76-5502-475b-b384-05aee205aa49)
![스크린샷 2025-06-20 오후 10 06 46](https://github.com/user-attachments/assets/5776f152-451f-4394-89cd-2e18015ce025)
![스크린샷 2025-06-20 오후 10 06 57](https://github.com/user-attachments/assets/78c3d79b-360c-4e5c-858b-2a5c970bde6b)

## *📢 To Reviewers*

- 코드리뷰 부탁드립니다.

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거 확인.
- [ ]  컨벤션 준수 확인.
