### PR TITLE
[Fix] 소셜로그인 중앙 정렬 및 기존 얼럿 커스텀 얼럿으로 교체

### DIFF
--- a/FitMate/FitMate/Common/Base/CustomAlertType.swift
+++ b/FitMate/FitMate/Common/Base/CustomAlertType.swift
@@ -1,0 +1,52 @@
+//
+//  CustomAlertType.swift
+//  FitMate
+//
+//  Created by soophie on 6/23/25.
+//
+
+import UIKit
+
+enum CustomAlertType {
+    case mateRequest(nickname: String)
+    case inviteSent(nickname: String)
+    case requestFailed(message: String)
+    case rejectRequest(message: String)
+
+    var title: String {
+        switch self {
+        case .mateRequest: return "메이트 요청 도착"
+        case .inviteSent: return "초대 전송 완료"
+        case .requestFailed: return "초대 요청 실패"
+        case .rejectRequest: return "메이트 요청이 거절됨"
+        }
+    }
+
+    var message: String {
+        switch self {
+        case .mateRequest:
+            return "상대방이 메이트 요청을 보냈습니다"
+        case .inviteSent(let nickname):
+            return "\(nickname)님에게 메이트 요청을 보냈습니다"
+        case .requestFailed(let message):
+            return message
+        case .rejectRequest(let message):
+            return message
+        }
+    }
+
+    var buttonStyle: ButtonType {
+        switch self {
+        case .mateRequest:
+            return .double("거절하기", "승인하기")
+        default:
+            return .single("확인")
+        }
+    }
+
+    enum ButtonType {
+        case single(String)
+        case double(String, String)
+    }
+}
+

--- a/FitMate/FitMate/Common/Components/CustomAlertViewController.swift
+++ b/FitMate/FitMate/Common/Components/CustomAlertViewController.swift
@@ -1,0 +1,125 @@
+//
+//  AcceptViewController.swift
+//  FitMate
+//
+//  Created by soophie on 6/23/25.
+//
+
+import UIKit
+import SnapKit
+
+final class CustomAlertViewController: UIViewController {
+    
+    /// 외부 클로저
+    /// alert 내부에서 외부 동작을 트리거하기 위함
+    /// CustomAlertViewController의 내부 로직이 아니라 외부에서 어떤 동작을 정의해서 넣고
+    /// Alert이 확인 버튼을 누를 때 호출해주는 방식이기 때문에 외부 클로저 필요
+    var onConfirm: (() -> Void)?
+    var onCancel: (() -> Void)?
+
+    private let alertType: CustomAlertType
+    private let cancelButton: UIButton = {
+       let cancel = UIButton()
+        cancel.titleLabel?.font = UIFont(name: "Pretendard-Regular", size: 18)
+        cancel.setTitleColor(.background500, for: .normal)
+        cancel.backgroundColor = .background50
+        cancel.layer.cornerRadius = 4
+        cancel.addTarget(self, action: #selector(didTapCancel), for: .touchUpInside)
+        return cancel
+    }()
+    private let confirmButton: UIButton = {
+       let confirm = UIButton()
+        confirm.titleLabel?.font = UIFont(name: "Pretendard-Regular", size: 18)
+        confirm.setTitleColor(.white, for: .normal)
+        confirm.backgroundColor = .primary500
+        confirm.layer.cornerRadius = 4
+        confirm.addTarget(self, action: #selector(didTapConfirm), for: .touchUpInside)
+        return confirm
+    }()
+
+    init(alertType: CustomAlertType) {
+        self.alertType = alertType
+        super.init(nibName: nil, bundle: nil)
+        modalPresentationStyle = .overFullScreen
+        modalTransitionStyle = .crossDissolve
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupBackground()
+        setupButtons()
+        setupAlertView()
+    }
+
+    private func setupBackground() {
+        view.backgroundColor = UIColor.black.withAlphaComponent(0.5)
+    }
+
+    private func setupButtons() {
+        cancelButton.snp.makeConstraints {
+            $0.height.equalTo(48)
+        }
+
+        confirmButton.snp.makeConstraints {
+            $0.height.equalTo(48)
+        }
+
+        switch alertType.buttonStyle {
+        case .single(let confirmText):
+            confirmButton.setTitle(confirmText, for: .normal)
+        case .double(let cancelText, let confirmText):
+            cancelButton.setTitle(cancelText, for: .normal)
+            confirmButton.setTitle(confirmText, for: .normal)
+        }
+    }
+
+    private func setupAlertView() {
+        let builder = CustomAlertView.AlertBuilder()
+            .setTitle(alertType.title)
+            .setMessage(alertType.message)
+
+        switch alertType.buttonStyle {
+        case .single: // 버튼 한개만 필요할때
+            builder.setStopButton(confirmButton)
+        case .double:
+            builder // 버튼 두개 필요할때
+                .setResumeButton(cancelButton)
+                .setStopButton(confirmButton)
+        }
+
+        let alertView = builder.buildAlert()
+        view.addSubview(alertView)
+        alertView.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.leading.trailing.equalToSuperview().inset(23)
+        }
+    }
+
+    @objc private func didTapCancel() {
+        dismiss(animated: true) { [weak self] in
+            self?.onCancel?()
+        }
+    }
+
+    @objc private func didTapConfirm() {
+        switch alertType {
+        case .mateRequest(let uid):
+            dismiss(animated: true) { [weak self] in
+                self?.onConfirm?()
+                guard let presentingVC = self?.presentingViewController else { return }
+                let codeShareVC = CodeShareViewController(uid: uid, hasMate: false)
+                let nav = UINavigationController(rootViewController: codeShareVC)
+                nav.modalPresentationStyle = .fullScreen
+                presentingVC.present(nav, animated: true)
+            }
+
+        case .inviteSent, .requestFailed, .rejectRequest:
+            // 확인만 누르면 dismiss
+            dismiss(animated: true)
+        }
+    }
+}

--- a/FitMate/FitMate/Common/Components/SocialLoginButton.swift
+++ b/FitMate/FitMate/Common/Components/SocialLoginButton.swift
@@ -46,20 +46,30 @@ import SnapKit
 
 class SocialLoginButton: UIButton {
     
-    let iconImageView: UIImageView = {
-        let iconImage = UIImageView()
-        iconImage.contentMode = .scaleAspectFit
-        return iconImage
+    private let iconImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFit
+        return imageView
     }()
     
-    let loginTitle: UILabel = {
-        let title = UILabel()
-        title.font = UIFont(name: "Pretendard-Medium", size: 20)
-        return title
+    private let loginTitleLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont(name: "Pretendard-Medium", size: 20)
+        label.textColor = .background900
+        return label
+    }()
+    
+    private lazy var loginStack: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [iconImageView, loginTitleLabel])
+        stack.axis = .horizontal
+        stack.spacing = 12
+        stack.alignment = .center
+        return stack
     }()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
+        setupLayout()
     }
     
     required init?(coder: NSCoder) {
@@ -72,21 +82,17 @@ class SocialLoginButton: UIButton {
         clipsToBounds = true
         
         iconImageView.image = UIImage(named: type.iconName)
-        loginTitle.text = type.title
-        loginTitle.textColor = type.textColor
-        
-        addSubview(iconImageView)
-        addSubview(loginTitle)
-        
         iconImageView.snp.makeConstraints { make in
-            make.leading.equalToSuperview().offset(73.5) // 공통 간격
-            make.centerY.equalToSuperview()
-            make.width.height.equalTo(24)
+            make.size.equalTo(24)
         }
-        
-        loginTitle.snp.makeConstraints { make in
-            make.leading.equalTo(iconImageView.snp.trailing).offset(8)
-            make.centerY.equalToSuperview()
+        loginTitleLabel.text = type.title
+        loginTitleLabel.textColor = type.textColor
+    }
+    
+    private func setupLayout() {
+        addSubview(loginStack)
+        loginStack.snp.makeConstraints { make in
+            make.center.equalToSuperview()
         }
     }
 }

--- a/FitMate/FitMate/Scene/CodeShare/View/CodeShareViewController.swift
+++ b/FitMate/FitMate/Scene/CodeShare/View/CodeShareViewController.swift
@@ -3,7 +3,6 @@
 //
 //  Created by 강성훈 on 6/5/25.
 //
-
 import UIKit
 import RxSwift
 import RxCocoa
@@ -11,15 +10,15 @@ import RxCocoa
 /// 메이트 초대 코드 공유 화면을 담당하는 ViewController
 /// - 역할: 초대 코드 복사, 메이트 코드 입력 화면 이동, 초대 수락/거절 처리, 매칭 완료 시 홈화면 전환
 final class CodeShareViewController: BaseViewController {
-    
+
     // MARK: - Properties
-    
+
     private let codeShareView = CodeShareView()
     private let viewModel: CodeShareViewModel
     private let uid: String // 로그인한 사용자 UID
     private let hasMate: Bool
     // MARK: - Initializer
-    
+
     /// 사용자 UID를 주입 받아 ViewModel을 초기화
     init(uid: String, hasMate: Bool) {
         self.uid = uid
@@ -27,30 +26,30 @@ final class CodeShareViewController: BaseViewController {
         self.viewModel = CodeShareViewModel(uid: uid)
         super.init(nibName: nil, bundle: nil)
     }
-    
+
     @MainActor required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     // MARK: - Lifecycle
-    
+
     override func loadView() {
         self.view = codeShareView
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         bind()
     }
-    
+
     // 시스템 네비게이션바 숨김
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationController?.setNavigationBarHidden(true, animated: false)
     }
-    
+
     // MARK: - Binding
-    
+
     /// ViewModel의 Input/Output을 구성하고 UI 이벤트에 바인딩
     private func bind() {
         let input = CodeShareViewModel.Input(
@@ -58,16 +57,16 @@ final class CodeShareViewController: BaseViewController {
             mateCodeTap: codeShareView.mateCodeButton.rx.tap.asObservable(),
             closeTap: codeShareView.xButton.rx.tap.asObservable()
         )
-        
+
         let output = viewModel.transform(input: input)
-        
+
         // 초대 코드 복사 후 Toast 출력
         output.copiedMessage
             .drive(onNext: { [weak self] message in
                 self?.showToast(message: message)
             })
             .disposed(by: disposeBag)
-        
+
         // 메이트 코드 입력 화면으로 이동
         output.navigateToMateCode
             .drive(onNext: { [weak self] in
@@ -76,57 +75,54 @@ final class CodeShareViewController: BaseViewController {
                 self.navigationController?.pushViewController(mateVC, animated: true)
             })
             .disposed(by: disposeBag)
-        
+
         // 닫기 버튼 눌렀을 때 현재 화면 dismiss
         output.dismiss
             .drive(onNext: { [weak self] in
                 guard let self = self else { return }
-                
+
                 let mateVC = TabBarController(uid: self.uid)
                 mateVC.mainVC.mainView.changeAvatarLayout(
                     hasMate: false, myNickname: "", mateNickname: "")
                 self.navigationController?.pushViewController(mateVC, animated: true)
             })
             .disposed(by: disposeBag)
-        
+
         // 사용자 초대 코드 텍스트 바인딩
         output.inviteCode
             .drive(codeShareView.copyRandomCodeButton.randomCode.rx.text)
             .disposed(by: disposeBag)
-        
+
         // 상대방이 나에게 초대 보냈을 때 Alert 표시
         output.showInviteAlert
             .emit(onNext: { [weak self] nickname in
                 self?.showInviteAlert(from: nickname)
             })
             .disposed(by: disposeBag)
-        
+
         // 메이트 수락되었을 때 홈(TabBar) 화면으로 이동
         output.transitionToMain
             .emit(onNext: { [weak self] in
                 self?.transitionToMain(uid: self?.uid ?? "")
             })
             .disposed(by: disposeBag)
-        
+
         output.rejectionAlert
             .emit(onNext: { [weak self] message in
                 self?.showRejectionAlert(message: message)
             })
             .disposed(by: disposeBag)
     }
-    
+
     private func showRejectionAlert(message: String) {
-        let alert = UIAlertController(
-            title: "메이트 요청이 거절됨",
-            message: message,
-            preferredStyle: .alert
+        let alert = CustomAlertViewController(
+            alertType: .rejectRequest(message: message)
         )
-        alert.addAction(UIAlertAction(title: "확인", style: .default))
         present(alert, animated: true)
     }
-    
+
     // MARK: - Alert
-    
+
     /// 상대방으로부터 초대 요청이 왔을 때 수락/거절 Alert 처리
     private func showInviteAlert(from nickname: String) {
         // Firestore에서 fromUid를 조회
@@ -134,26 +130,29 @@ final class CodeShareViewController: BaseViewController {
             .subscribe(onSuccess: { [weak self] data in
                 guard let self = self else { return }
                 guard let fromUid = data["fromUid"] as? String else { return }
-                
-                let alert = UIAlertController(
-                    title: "메이트 요청 도착",
-                    message: "\(nickname)님이 메이트 요청을 보냈습니다.",
-                    preferredStyle: .alert
-                )
-                
-                // 수락 버튼 눌렀을 때 매칭 수락 처리 및 화면 전환
-                alert.addAction(UIAlertAction(title: "수락", style: .default, handler: { _ in
+
+                let alert = CustomAlertViewController(
+                    alertType: .mateRequest(nickname: nickname))
+                /// 수락 액션
+                alert.onConfirm = { [weak self] in
+                    guard let self = self else { return }
+                    // 수락 버튼 눌렀을 때 매칭 수락 처리 및 화면 전환
                     self.viewModel.acceptInvite(fromUid: fromUid)
+                    // 완료 되면 화면 전환
                         .subscribe(onCompleted: {
                             self.transitionToMain(uid: self.uid)
+                            // 에러나면 showToast
                         }, onError: { error in
                             self.showToast(message: "수락 실패: \(error.localizedDescription)")
                         })
                         .disposed(by: self.disposeBag)
-                }))
-                
+                }
+                self.present(alert, animated: true)
+
                 // 거절 버튼 눌렀을 때 Firestore 상태 초기화
-                alert.addAction(UIAlertAction(title: "거절", style: .cancel, handler: { _ in
+                alert.onCancel = { [weak self] in
+                    guard let self = self else { return }
+
                     self.viewModel.rejectInvite()
                         .subscribe(onCompleted: {
                             self.showToast(message: "메이트 요청을 거절했습니다")
@@ -161,27 +160,25 @@ final class CodeShareViewController: BaseViewController {
                             self.showToast(message: "거절 실패: \(error.localizedDescription)")
                         })
                         .disposed(by: self.disposeBag)
-                }))
-                
-                self.present(alert, animated: true)
-                
+                }
+
             }, onFailure: { error in
                 print("fromUid 조회 실패: \(error.localizedDescription)")
             })
             .disposed(by: disposeBag)
     }
-    
+
     // MARK: - 화면 전환
-    
+
     /// 매칭 수락 완료 후 TabBarController로 전환하여 메인 화면 진입
     private func transitionToMain(uid: String) {
         guard let sceneDelegate = UIApplication.shared.connectedScenes
             .first?.delegate as? SceneDelegate else { return }
-        
+
         let tabBarController = TabBarController(uid: uid)
-        
+
         guard let window = sceneDelegate.window else { return }
-        
+
         UIView.transition(with: window,
                           duration: 0.5,
                           options: .transitionCrossDissolve,
@@ -189,9 +186,9 @@ final class CodeShareViewController: BaseViewController {
             window.rootViewController = tabBarController
         })
     }
-    
+
     // MARK: - Toast
-    
+
     /// 사용자에게 간단한 메시지를 Toast 형태로 출력
     private func showToast(message: String) {
         let toastLabel = UILabel()
@@ -203,10 +200,10 @@ final class CodeShareViewController: BaseViewController {
         toastLabel.alpha = 0
         toastLabel.layer.cornerRadius = 8
         toastLabel.clipsToBounds = true
-        
+
         toastLabel.frame = CGRect(x: 50, y: view.frame.size.height - 100, width: view.frame.size.width - 100, height: 35)
         view.addSubview(toastLabel)
-        
+
         UIView.animate(withDuration: 0.5, animations: {
             toastLabel.alpha = 1.0
         }) { _ in
@@ -217,9 +214,9 @@ final class CodeShareViewController: BaseViewController {
             })
         }
     }
-    
+
     // MARK: - 메모리 해제
-    
+
     /// Firestore 실시간 리스너 해제
     deinit {
         viewModel.stopListening()

--- a/FitMate/FitMate/Scene/CodeShare/View/MateCodeViewController.swift
+++ b/FitMate/FitMate/Scene/CodeShare/View/MateCodeViewController.swift
@@ -48,7 +48,6 @@ final class MateCodeViewController: BaseViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        bindViewModel()
         setupActions()
     }
     
@@ -108,26 +107,23 @@ final class MateCodeViewController: BaseViewController {
     
     // MARK: - Alert
     /// ViewModel이 방출한 AlertType 에 따라 알림창 구성 및 출력
-    private func presentAlert(for alert: AlertType) {
-        let alertController: UIAlertController
-        
+    private func presentAlert(for alert: CustomAlertType) {
+        let customType: CustomAlertType
+
         switch alert {
         case .inviteSent(let nickname):
-            alertController = UIAlertController(
-                title: "초대 전송 완료",
-                message: "\(nickname)님에게 메이트 요청을 보냈습니다.",
-                preferredStyle: .alert
-            )
+            customType = .inviteSent(nickname: nickname)
         case .requestFailed(let message):
-            alertController = UIAlertController(
-                title: "초대 요청 실패",
-                message: message,
-                preferredStyle: .alert
-            )
+            customType = .requestFailed(message: message)
+        case .mateRequest(let nickname):
+            customType = .mateRequest(nickname: nickname)
+        case .rejectRequest(message: let message):
+            customType = .rejectRequest(message: message)
         }
-        
-        alertController.addAction(UIAlertAction(title: "확인", style: .default))
-        self.present(alertController, animated: true)
+
+        let alertVC = CustomAlertViewController(alertType: customType)
+        self.present(alertVC, animated: true)
     }
+
     
 }

--- a/FitMate/FitMate/Scene/CodeShare/ViewModel/MateCodeViewModel.swift
+++ b/FitMate/FitMate/Scene/CodeShare/ViewModel/MateCodeViewModel.swift
@@ -14,6 +14,7 @@ import FirebaseFirestore
 enum AlertType {
     case inviteSent(String) // "OOO님에게 초대가 전송되었습니다."
     case requestFailed(String)
+    case mateReqeust(String)
 }
 
 /// 화면 전환 목적 정의
@@ -33,7 +34,7 @@ class MateCodeViewModel {
     
     /// ViewModel → ViewController로 전달되는 처리 결과
     struct Output {
-        let result: Driver<(AlertType?, Navigation?)> // 알림 및 화면 전환 정보
+        let result: Driver<(CustomAlertType?, Navigation?)> // 알림 및 화면 전환 정보
         let buttonActivated: Driver<Bool> // 버튼 활성화 여부
     }
     
@@ -58,25 +59,25 @@ class MateCodeViewModel {
         /// '입력 완료' 버튼이 눌렸을 때 가장 최신 코드 값을 가져와서 처리
         let result = input.completeTap
             .withLatestFrom(input.enteredCode) // 버튼 누를 시점의 입력값 사용
-            .flatMapLatest { [weak self] code -> Observable<(AlertType?, Navigation?)> in
+            .flatMapLatest { [weak self] code -> Observable<(CustomAlertType?, Navigation?)> in
                 // ViewModel이 해제되었을 경우 에러 처리
                 guard let self = self else {
-                    return Observable.just((.requestFailed("사용자 인증 실패"), nil))
+                    return Observable.just((.requestFailed(message: "사용자 인증 실패"), nil))
                 }
 
                 // 입력한 초대 코드로 Firestore에서 해당 유저 문서 조회
                 return self.firestoreService
                     .fetchUserByInviteCode(code)
-                    .flatMap { inviterData -> Single<(AlertType?, Navigation?)> in
+                    .flatMap { inviterData -> Single<(CustomAlertType?, Navigation?)> in
                         // 조회된 데이터에서 uid, nickname 추출
                         guard let inviterUid = inviterData["uid"] as? String,
                               let inviterNickname = inviterData["nickname"] as? String else {
-                            return .just((.requestFailed("올바르지 않은 사용자 정보입니다"), nil))
+                            return .just((.requestFailed(message: "올바르지 않은 사용자 정보입니다"), nil))
                         }
                         
                         // 자신의 초대코드를 입력한 경우 → 에러 처리
                         if inviterUid == self.uid {
-                            return .just((.requestFailed("자신의 초대 코드는 입력할 수 없습니다."), nil))
+                            return .just((.requestFailed(message: "자신의 초대 코드는 입력할 수 없습니다."), nil))
                         }
 
                         // 해당 사용자의 문서에 초대 상태, 보낸 사람 UID 업데이트
@@ -89,17 +90,17 @@ class MateCodeViewModel {
                         // 문서 업데이트 성공 시 알림 + 화면 뒤로 이동 신호 반환
                         return self.firestoreService
                             .updateDocument(collectionName: "users", documentName: inviterUid, fields: fields)
-                            .map { (.inviteSent(inviterNickname), .backTo) }
+                            .map { (.inviteSent(nickname: inviterNickname), .backTo) }
                     }
                     .asObservable()
                     .catch { error in
                         // 에러 발생 시 실패 알림 반환
-                        return Observable.just((.requestFailed(error.localizedDescription), nil))
+                        return Observable.just((.requestFailed(message: error.localizedDescription), nil))
                     }
             }
             .asDriver(onErrorRecover: { error in
                 // 예상치 못한 오류에도 안전하게 처리
-                return Driver.just((.requestFailed(error.localizedDescription), nil))
+                return Driver.just((.requestFailed(message: error.localizedDescription), nil))
             })
 
         // Output으로 전달


### PR DESCRIPTION
close #170 
<!-- close #No(이슈 넘버 등록하면 자동으로 이슈가 닫힙니다. 이슈를 닫고 싶지 않다면, 즉 해당 이슈의 작업이 아직 끝나지 않았다면 닫지 않습니다.) -->

## *⛳️ Work Description*

- 소셜 로그인 로고+타이틀 스택으로 묶고 중앙 정렬
- 코드 공유 화면 쪽 시스템 얼럿 -> 커스텀 얼럿 교체

## *📸 Screenshot*


![Simulator Screen Recording - iPhone 13 mini - 2025-06-23 at 16 09 03](https://github.com/user-attachments/assets/560a815c-6064-446d-b3eb-4f8316635f59)


## *📢 To Reviewers*

- 코드리뷰 부탁드립니다.

## *✅ Checklist*

<!-- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다. -->

- [x]  주석 및 프린트문 제거 확인.
- [x]  컨벤션 준수 확인.
