### PR TITLE
[FIx] #175 카카오 로그인 취소 시 모든 동작 멈추던 오류 수정

### DIFF
--- a/FitMate/FitMate/Common/Service/Firebase/Auth/AuthService.swift
+++ b/FitMate/FitMate/Common/Service/Firebase/Auth/AuthService.swift
@@ -14,6 +14,25 @@ import KakaoSDKAuth
 import AuthenticationServices
 import CryptoKit
 
+enum KakaoLoginError: LocalizedError {
+  case userCancelled
+  case networkError
+  case invalidToken
+  case unknownError(String)
+  var errorDescription: String? {
+    switch self {
+    case .userCancelled:
+      return "사용자가 로그인을 취소했습니다."
+    case .networkError:
+      return "네트워크 연결을 확인해주세요."
+    case .invalidToken:
+      return "로그인 토큰이 유효하지 않습니다."
+    case .unknownError(let message):
+      return message
+    }
+  }
+}
+
 typealias KakaoUser = KakaoSDKUser.User
 
 final class AuthService: NSObject {


### PR DESCRIPTION
close #175 
<!-- close #No(이슈 넘버 등록하면 자동으로 이슈가 닫힙니다. 이슈를 닫고 싶지 않다면, 즉 해당 이슈의 작업이 아직 끝나지 않았다면 닫지 않습니다.) -->

## *⛳️ Work Description*

-  카카오 로그인 취소 시 모든 동작 멈추던 오류 수정
- 기존에는 observer.onError(error)가 호출되면 그 시점에 에러가 바깥으로 터지고 스트림은 즉시 종료
- 구글과 애플처럼 에러 반환 시  Result.failure(error) 로 포장해서 다음으로 넘김

## *📸 Screenshot*
![Simulator Screen Recording - iPhone 13 mini - 2025-06-23 at 19 33 20](https://github.com/user-attachments/assets/5ff35329-0108-4880-8016-89784807fa44)



## *📢 To Reviewers*

<!-- 이 PR을 리뷰하는 사람들에게 할 말이 있다면 작성하시면 됩니다. -->

- 코드리뷰 부탁드립니다.

## *✅ Checklist*

<!-- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다. -->

- [x]  주석 및 프린트문 제거 확인.
- [x]  컨벤션 준수 확인.
