### PR TITLE
[Fix] #195 패배 화면 이미지 안나오는 버그 픽스

### DIFF
--- a/FitMate/FitMate/Scene/Finish/ViewModel/FinishViewModel.swift
+++ b/FitMate/FitMate/Scene/Finish/ViewModel/FinishViewModel.swift
@@ -46,7 +46,7 @@ final class FinishViewModel: ViewModelType {
 //        let hideCoin = Observable.just(!success)
         let myDistance: Double // 실제 달성 거리 (ex. 2.4Km)
         let result = Observable.just(resultMessage)
-        let resultImage = Observable.just(success ? "win" : "lose")
+        let resultImage = Observable.just(success ? "win" : "Lose")
         let characterImage = Observable.just(success ? character : "\(character)Lose")
 
         return Output(


### PR DESCRIPTION
close #195 
<!-- close #No(이슈 넘버 등록하면 자동으로 이슈가 닫힙니다. 이슈를 닫고 싶지 않다면, 즉 해당 이슈의 작업이 아직 끝나지 않았다면 닫지 않습니다.) -->

## *⛳️ Work Description*

<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- 패배 화면 이미지 안나오는 버그 픽스

## *📸 Screenshot*
<img src="https://github.com/user-attachments/assets/56ba5709-a72f-486b-b338-b71386b90b7f" width=50%>

<!-- 구현한 부분의 시뮬레이터 스크린샷을 올려주시면 됩니다. -->
<!-- 기기대응을 위해 사이즈가 다른 기기별로 스크린샷을 올리기도 합니다. -->
<!-- 움직이는 동작일 경우, 시뮬레이터 영상을 녹화하고 gif로 저장하여 드래그 앤 드롭을 통해 업로드하면 됩니다. -->

## *📢 To Reviewers*

<!-- 이 PR을 리뷰하는 사람들에게 할 말이 있다면 작성하시면 됩니다. -->

- 코드리뷰 부탁드립니다.

## *✅ Checklist*

<!-- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다. -->

- [x]  주석 및 프린트문 제거 확인.
- [x]  컨벤션 준수 확인.
