### PR TITLE
[Fix] #208 메이트로 워딩 통일 및 메인 화면 UI 비율로 조정

### DIFF
--- a/FitMate/FitMate/Scene/CodeShare/View/CodeShareView.swift
+++ b/FitMate/FitMate/Scene/CodeShare/View/CodeShareView.swift
@@ -31,7 +31,7 @@ class CodeShareView: BaseView {
     
     let guideMent: UILabel = {
         let guide = UILabel()
-        guide.text = "파트너 연결 후 시작해보세요"
+        guide.text = "메이트 연결 후 시작해보세요"
         guide.textColor = .background100
         guide.font = UIFont(name: "Pretendard-Regular", size: 16)
         return guide

--- a/FitMate/FitMate/Scene/CodeShare/View/MateCodeView.swift
+++ b/FitMate/FitMate/Scene/CodeShare/View/MateCodeView.swift
@@ -39,7 +39,7 @@ class MateCodeView: BaseView {
         return image
     }()
     
-    let fillInMateCode = CustomTextField(placeholder: "파트너 코드를 입력해주세요")
+    let fillInMateCode = CustomTextField(placeholder: "메이트 코드를 입력해주세요")
     
     let completeButton: UIButton = {
         let button = UIButton()

--- a/FitMate/FitMate/Scene/GoalSelection/View/GoalSelectionViewController.swift
+++ b/FitMate/FitMate/Scene/GoalSelection/View/GoalSelectionViewController.swift
@@ -48,7 +48,7 @@ class GoalSelectionViewController: BaseViewController, UIPickerViewDataSource, U
         let label = UILabel()
         label.font = UIFont(name: "pretendard-regular", size: 16)
         label.textAlignment = .left
-        label.text = "파트너와 함께 정해보세요"
+        label.text = "메이트와 함께 정해보세요"
         label.textColor = .lightGray
         label.numberOfLines = 0
         return label

--- a/FitMate/FitMate/Scene/Login/View/LoginView.swift
+++ b/FitMate/FitMate/Scene/Login/View/LoginView.swift
@@ -64,19 +64,19 @@ class LoginView: BaseView {
         kakaoLogin.snp.makeConstraints { make in
             make.top.equalTo(fitMateLogo.snp.bottom).offset(140)
             make.leading.trailing.equalToSuperview().inset(20)
-            make.height.equalTo(60)
+            make.height.equalTo(kakaoLogin.snp.width).multipliedBy(0.179)
         }
         
         googleLogin.snp.makeConstraints { make in
             make.top.equalTo(kakaoLogin.snp.bottom).offset(16)
             make.leading.trailing.equalToSuperview().inset(20)
-            make.height.equalTo(60)
+            make.height.equalTo(googleLogin.snp.width).multipliedBy(0.179)
         }
         
         appleLogin.snp.makeConstraints { make in
             make.top.equalTo(googleLogin.snp.bottom).offset(16)
             make.leading.trailing.equalToSuperview().inset(20)
-            make.height.equalTo(60)
+            make.height.equalTo(appleLogin.snp.width).multipliedBy(0.179)
         }
     }
 }

--- a/FitMate/FitMate/Scene/Main/View/MainView.swift
+++ b/FitMate/FitMate/Scene/Main/View/MainView.swift
@@ -49,6 +49,8 @@ class MainView: BaseView {
         dDay.text = "1일째"
         dDay.font = UIFont(name: "DungGeunMo", size: 40)
         dDay.textColor = .secondary500
+//        dDay.minimumScaleFactor = 0.1 // 외부 제약이 명시적일때 그 제약에 맞게
+        dDay.adjustsFontSizeToFitWidth = true
         return dDay
     }()
     
@@ -142,6 +144,7 @@ class MainView: BaseView {
         dDaysLabel.snp.makeConstraints { make in
             make.top.equalTo(explainLabel.snp.bottom)
             make.leading.equalToSuperview().inset(28)
+            make.width.equalTo(dDaysLabel.snp.height).multipliedBy(2.3)
         }
         
         myAvatarImage.snp.makeConstraints { make in
@@ -156,8 +159,8 @@ class MainView: BaseView {
         exerciseButton.snp.makeConstraints { make in
             make.bottom.equalToSuperview().inset(32)
             make.centerX.equalToSuperview()
-            make.width.equalTo(335)
-            make.height.equalTo(60)
+            make.leading.trailing.equalToSuperview().inset(20)
+            make.height.equalTo(exerciseButton.snp.width).multipliedBy(0.17)
         }
 
     }
@@ -180,8 +183,7 @@ class MainView: BaseView {
             make.leading.equalToSuperview().inset(hasMate ? 44: 68)
             make.trailing.equalToSuperview().inset(hasMate ? 123 : 67)
             make.bottom.equalTo(exerciseButton.snp.top).offset(-40)
-//            make.width.equalTo(hasMate ? 208 : 240)
-            make.height.equalTo(hasMate ? 267 : 309)
+            make.height.equalTo(myAvatarImage.snp.width).multipliedBy(1.283)
         }
         // 내 아바타 상단 닉네임 라벨 위치 설정
         myNicknameStack.snp.remakeConstraints { make in
@@ -190,16 +192,17 @@ class MainView: BaseView {
         }
         // 상대방 아바타 위치 및 크기 설정
         mateAvatarImage.snp.remakeConstraints { make in
-            make.top.equalTo(topBar.snp.bottom).offset(25)
-            make.trailing.equalTo(safeAreaLayoutGuide).inset(40)
-            make.height.equalTo(142)
-            make.width.equalTo(112)
+            make.top.equalTo(topBar.snp.bottom).offset(30)
+            make.leading.equalToSuperview().inset(240)
+            make.trailing.equalToSuperview().inset(26)
+            make.height.equalTo(mateAvatarImage.snp.width).multipliedBy(0.9)
         }
         // 상대방 아바타 상단 닉네임 라벨 위치 설정
         mateNicknameStack.snp.remakeConstraints { make in
             make.centerX.equalTo(mateAvatarImage)
             make.bottom.equalTo(mateAvatarImage.snp.top).inset(-10)
         }
+        
 //        // 메이트 없을 때는 안보이게 처리
 //        mateAvatarImage.isHidden = !hasMate // = hasMate가 false면 안보이도록
 //        print("기대값false:\(hasMate)")

--- a/FitMate/FitMate/Scene/Setting/View/SettingView.swift
+++ b/FitMate/FitMate/Scene/Setting/View/SettingView.swift
@@ -69,7 +69,7 @@ final class SettingView: UIView {
         return view
     }()
 
-    let partnerButton = SettingView.makeButton(title: "파트너 종료")
+    let partnerButton = SettingView.makeButton(title: "메이트 끊기")
     let logoutButton = SettingView.makeButton(title: "로그아웃")
     let withdrawButton = SettingView.makeButton(title: "회원탈퇴")
 


### PR DESCRIPTION
close #208 
<!-- close #No(이슈 넘버 등록하면 자동으로 이슈가 닫힙니다. 이슈를 닫고 싶지 않다면, 즉 해당 이슈의 작업이 아직 끝나지 않았다면 닫지 않습니다.) -->

## *⛳️ Work Description*

- height 명시하던 부분 모두 multipleby 비율로 변경
- 메이트로 워딩 통일

## *📸 Screenshot*

<img src="https://github.com/user-attachments/assets/c0178a4d-77a6-42ac-b91f-acf4c539b09b" width="50%">
16 Pro Max

<img src="https://github.com/user-attachments/assets/92aff17e-28a5-40a9-ba40-145860458723" width="50%">
13 Mini


## *📢 To Reviewers*

<!-- 이 PR을 리뷰하는 사람들에게 할 말이 있다면 작성하시면 됩니다. -->

- 코드리뷰 부탁드립니다.

## *✅ Checklist*

<!-- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다. -->

- [x]  주석 및 프린트문 제거 확인.
- [x]  컨벤션 준수 확인.
