### PR TITLE
[Fix] #239 FCM 토큰 저장 위치 및 저장 시점 변경

### DIFF
--- a/FitMate/FitMate/Scene/Login/ViewModel/LoginViewModel.swift
+++ b/FitMate/FitMate/Scene/Login/ViewModel/LoginViewModel.swift
@@ -12,6 +12,7 @@ import UIKit
 import KakaoSDKUser
 import KakaoSDKAuth
 import CryptoKit
+import FirebaseMessaging
 
 final class LoginViewModel {
     
@@ -72,6 +73,11 @@ final class LoginViewModel {
                         .catch { _ in // 사용자 문서가 존재하지 않다면
                             return FirestoreService.shared
                                 .createUserDocument(uid: uid) // 사용자 uid 로 문서를 생성
+                                .do(onSuccess: { _ in
+                                    if let token = Messaging.messaging().fcmToken {
+                                        AppDelegate.saveFCMToken(token)
+                                    }
+                                })
                                 .map { .goToInputNickName(uid: uid) } // .just(.goToInputNickName(uid: uid)로 반환
                         }
                         .asObservable()
@@ -97,7 +103,7 @@ final class LoginViewModel {
                                     domain: "kakao",
                                     code: -1,
                                     userInfo: [NSLocalizedDescriptionKey: "유저 정보 없음"]
-                                ))
+                                                        ))
                             }
                         }
                     }
@@ -170,6 +176,11 @@ final class LoginViewModel {
                         .catch {_ in
                             FirestoreService.shared
                                 .createUserDocument(uid: uid)
+                                .do(onSuccess: { _ in
+                                    if let token = Messaging.messaging().fcmToken {
+                                        AppDelegate.saveFCMToken(token)
+                                    }
+                                })
                                 .map { .goToInputNickName(uid: uid) }
                         }
                         .asObservable()
@@ -212,6 +223,11 @@ final class LoginViewModel {
                         .catch { _ in
                             FirestoreService.shared
                                 .createUserDocument(uid: uid)
+                                .do(onSuccess: { _ in
+                                    if let token = Messaging.messaging().fcmToken {
+                                        AppDelegate.saveFCMToken(token)
+                                    }
+                                })
                                 .map { .goToInputNickName(uid: uid) }
                         }
                         .asObservable()


### PR DESCRIPTION
close #239

## *⛳️ Work Description*

- fcm토큰이 저장 되는 시점이 유저 문서가 생기기 전이라 유저에 생기지 않고 새로 문서가 생김
- 저장 방식을 머지로 변경하게 안전하게 덮어씌어지게 변경함
- 저장 시점을 문서가 생긴 이후로 변경
- 로그아웃시 토큰  삭제

## *📸 Screenshot*

- 스크린샷 필요 없읍니당

## *📢 To Reviewers*

- 코드리뷰 부탁드립니다.

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거 확인.
- [ ]  컨벤션 준수 확인.
