### PR TITLE
[Fix] #240 줄넘기 대결모드 승패 바뀌어서 저장되는 버그 픽스

### DIFF
--- a/FitMate/FitMate/Scene/Finish/View/FinishViewController.swift
+++ b/FitMate/FitMate/Scene/Finish/View/FinishViewController.swift
@@ -88,11 +88,7 @@ class FinishViewController: BaseViewController {
         finishView.rewardButton.rx.tap
             .bind { [weak self] in
                 guard let self else { return }
-                
 
-                print("self.matchCode: \(self.matchCode)\nmyUid: \(self.uid)\nmateUid: \(self.mateUid)\nmode: \(viewModel.mode)\nisWinner: \(viewModel.success)\ngoal: \(viewModel.goal)\nexerciseType: \(viewModel.sport)")
-                
-                // 업데이트 실행
                 FirestoreService.shared.updateMatchResult(
                     matchCode: self.matchCode,
                     myUid: self.uid,
@@ -103,8 +99,15 @@ class FinishViewController: BaseViewController {
                     myDistance: viewModel.myDistance,
                     exerciseType: viewModel.sport
                 )
+                .andThen(
+                    self.viewModel.saveRecord(
+                        uid: self.uid,
+                        mateUid: self.mateUid,
+                        matchCode: self.matchCode
+                    )
+                )
                 .subscribe(onCompleted: {
-                    print("파이어스토어 업데이트 완료")
+                    print("✅ 유저 기록 저장 완료")
 
                     let tabBarVC = TabBarController(uid: self.uid)
                     tabBarVC.modalPresentationStyle = .fullScreen
@@ -115,19 +118,10 @@ class FinishViewController: BaseViewController {
                         window.makeKeyAndVisible()
                     }
                 }, onError: { error in
-                    print("업데이트 실패: \(error)")
+                    print("❌ 유저 기록 저장 실패: \(error.localizedDescription)")
                 })
                 .disposed(by: self.disposeBag)
             }
-            .disposed(by: disposeBag)
-        
-        viewModel
-            .saveRecord(uid: self.uid, mateUid: mateUid, matchCode: matchCode)
-            .subscribe(onCompleted: {
-                print("✅ 유저 기록 저장 완료")
-            }, onError: { error in
-                print("❌ 유저 기록 저장 실패: \(error.localizedDescription)")
-            })
             .disposed(by: disposeBag)
     }
 }

--- a/FitMate/FitMate/Scene/JumpRope/JumpRopeBattle/View/JumpRopeBattleViewController.swift
+++ b/FitMate/FitMate/Scene/JumpRope/JumpRopeBattle/View/JumpRopeBattleViewController.swift
@@ -1,6 +1,7 @@
 import RxSwift
 import Foundation
 import RxCocoa
+import FirebaseFirestore
 
 // JumpRope 대결 모드 컨트롤러 (전체 흐름 제어, ViewModel과 View 연결 담당)
 class JumpRopeBattleViewController: BaseViewController {
@@ -12,7 +13,7 @@ class JumpRopeBattleViewController: BaseViewController {
     // 시작 트리거용(버튼, viewDidLoad 등에서 신호 보낼 때 사용)
     private let startRelay = PublishRelay<Void>()
     // 메이트 점프 횟수 수신용(상대방이 firebase에서 온 값으로 갱신할 때 쓸 수도 있음)
-    private let mateCountRelay = PublishRelay<Int>()
+    private let mateCountRelay = PublishRelay<Double>()
     private let quitRelay = PublishRelay<Void>()
     private let mateQuitRelay = PublishRelay<Void>()
     private let myCharacter: String
@@ -54,7 +55,14 @@ class JumpRopeBattleViewController: BaseViewController {
         //(파이널베이스 내의 만약 캐릭터 이미지 바인딩 시 이곳에서)
         sportsView.updateMyCharacter(myCharacter)
         sportsView.updateMateCharacter(mateCharacter)
+        
+//        FirestoreService.shared
+//            .observeMateProgress(matchCode: matchCode, mateUid: mateUid)
+//            .bind(to: mateCountRelay)
+//            .disposed(by: disposeBag)
+        
         startRelay.accept(())
+        
         sportsView.stopButton.rx.tap
             .bind { [weak self] in
                 self?.sportsView.showQuitAlert(
@@ -72,7 +80,7 @@ class JumpRopeBattleViewController: BaseViewController {
             }
             .disposed(by: disposeBag)
     }
-        
+    
     // ViewModel과 UI 바인딩
     override func bindViewModel() {
         let input = JumpRopeBattleViewModel.Input(
@@ -98,10 +106,10 @@ class JumpRopeBattleViewController: BaseViewController {
             .disposed(by: disposeBag)
         
         output.didFinish
-                   .emit(onNext: { [weak self] success in
-                       self?.navigateToFinish(success: success)
-                   })
-                   .disposed(by: disposeBag)
+            .emit(onNext: { [weak self] success in
+                self?.navigateToFinish(success: success)
+            })
+            .disposed(by: disposeBag)
         
         // 내 진행률바(비율)
         output.myProgressView
@@ -109,6 +117,7 @@ class JumpRopeBattleViewController: BaseViewController {
                 self?.sportsView.myUpdateProgress(ratio: ratio)
             })
             .disposed(by: disposeBag)
+        
         // 메이트 진행률바(비율)x
         output.mateProgressView
             .drive(onNext: { [weak self] ratio in
@@ -122,6 +131,7 @@ class JumpRopeBattleViewController: BaseViewController {
             })
             .disposed(by: disposeBag)
     }
+    
     // 피니쉬화면으로 이동
     private func navigateToFinish(success: Bool) {
         let finishVM = FinishViewModel(
@@ -133,12 +143,54 @@ class JumpRopeBattleViewController: BaseViewController {
             character: myCharacter,
             success: success
         )
-        let vc = FinishViewController(uid: myUid, mateUid: mateUid, matchCode: matchCode, viewModel: finishVM)
+        
+        let vc = FinishViewController(
+            uid: myUid,
+            mateUid: mateUid,
+            matchCode: matchCode,
+            viewModel: finishVM
+        )
+        
         vc.modalPresentationStyle = .fullScreen
         present(vc, animated: true)
     }
+    
+    private func navigateToFinish() {
+        Firestore.firestore().collection("matches").document(matchCode)
+            .getDocument { [weak self] snapshot, error in
+                guard let self = self else { return }
+                guard let data = snapshot?.data(),
+                      let players = data["players"] as? [String: Any],
+                      let myData = players[self.myUid] as? [String: Any],
+                      let isWinner = myData["isWinner"] as? Bool else {
+                    print("🔥 승자 정보 불러오기 실패")
+                    return
+                }
+
+                let finishVM = FinishViewModel(
+                    mode: .battle,
+                    sport: "줄넘기",
+                    goal: self.viewModel.goalCount,
+                    goalUnit: "개",
+                    myDistance: Double(self.viewModel.myCount),
+                    character: self.myCharacter,
+                    success: isWinner  // ✅ Firestore에서 가져온 최종 결과
+                )
+
+                let vc = FinishViewController(
+                    uid: self.myUid,
+                    mateUid: self.mateUid,
+                    matchCode: self.matchCode,
+                    viewModel: finishVM
+                )
+                vc.modalPresentationStyle = .fullScreen
+                self.present(vc, animated: true)
+            }
+    }
+    
     func receiveMateQuit()    {
         viewModel.stopLocationUpdates()
+        
         sportsView.showQuitAlert(
             type: .mateQuit,
             onBack: { [weak self] in
@@ -146,7 +198,8 @@ class JumpRopeBattleViewController: BaseViewController {
                 //self?.navigationController?.popToRootViewController(animated: true)
                 
                 self?.viewModel.finish(success: true) // ✅ 위치 정지 및 기록 저장
-                self?.navigateToFinish(success: true)
+                //self?.navigateToFinish(success: true)
+                self?.navigateToFinish()
             }
         )
     }

--- a/FitMate/FitMate/Scene/JumpRope/JumpRopeBattle/ViewModel/JumpRopeBattleViewModel.swift
+++ b/FitMate/FitMate/Scene/JumpRope/JumpRopeBattle/ViewModel/JumpRopeBattleViewModel.swift
@@ -67,23 +67,12 @@ final class JumpRopeBattleViewModel: ViewModelType {
         input.start
             .subscribe(onNext: { [weak self] in
                 self?.startAccelerometer()
-                //                                self?.observeMateCount()
+                // self?.observeMateCount()
                 // 메이트 종료 감지
                 self?.bindMateQuitListener()
                 self?.observeMateCount() // ✅ 메이트 점프 수 감지 시작
             })
             .disposed(by: disposeBag)
-        
-        // 메이트 점프 수가 들어오면 Relay에 바인딩
-//        input.mateCount
-//            .subscribe(onNext: { [weak self] count in
-//                guard let self else { return }
-//                self.mateCountRelay.accept(count)
-//                if self.mateCountRelay.value >= self.goalCount {
-//                    self.finish(success: false)
-//                }
-//            })
-//            .disposed(by: disposeBag)
         
         input.quit
             .subscribe(onNext: { [weak self] in self?.confirmQuit(isMine: true) })
@@ -92,6 +81,15 @@ final class JumpRopeBattleViewModel: ViewModelType {
         input.mateQuit
             .subscribe(onNext: { [weak self] in self?.confirmQuit(isMine: false) })
             .disposed(by: disposeBag)
+        
+//        input.mateCount
+//            .subscribe(onNext: { [weak self] count in
+//                guard let self else {return}
+//                self.mateCountRelay.accept(Int(count))
+//                if Int(count) >= self.goalCount {
+//                    self.finish(success: false)
+//                }
+//            }).disposed(by: disposeBag)
         
         // 내 점프 수를 문자열로 변환(Driver로 변환)
         let myText = myCountRelay
@@ -102,21 +100,6 @@ final class JumpRopeBattleViewModel: ViewModelType {
         let mateText = mateCountRelay
             .map { "\($0)개" }
             .asDriver(onErrorJustReturn: "0")
-        
-        // 내 점프 수와 메이트 점프 수를 더해서, 목표 대비 진행률 계산
-//        let myProgress = myCountRelay
-//            .map { [weak self] my -> CGFloat in
-//                guard let self else { return 0 }
-//                return CGFloat(min(1, Float(my) / Float(self.goalCount)))
-//            }
-//            .asDriver(onErrorJustReturn: 0)
-//        
-//        let mateProgress = mateCountRelay
-//            .map { [weak self] mate -> CGFloat in
-//                guard let self else { return 0 }
-//                return CGFloat(min(1, Float(mate) / Float(self.goalCount)))
-//            }
-//            .asDriver(onErrorJustReturn: 0)
         
         let myProgress = myCountRelay
             .map { CGFloat(min(1.0, Float($0) / Float(self.goalCount))) }
@@ -166,6 +149,7 @@ final class JumpRopeBattleViewModel: ViewModelType {
             }
         }
     }
+    
     private func confirmQuit(isMine: Bool) {
         motionManager.stopAccelerometerUpdates()
         //finish(success: false)
@@ -189,6 +173,7 @@ final class JumpRopeBattleViewModel: ViewModelType {
         motionManager.stopAccelerometerUpdates()
         didFinishRelay.accept(success)
     }
+    
     // 내 점프수 Firestore에 저장 (실시간)
     private func updateMyCountToFirestore(_ count: Int) {
         db.collection("matches")
@@ -203,17 +188,8 @@ final class JumpRopeBattleViewModel: ViewModelType {
                 }
             }
     }
-    //
+
     // 메이트 점프 수를 Firestore에서 실시간 감지
-//    private func observeMateCount() {
-//        db.collection("matches")
-//            .document(matchCode)
-//            .addSnapshotListener { [weak self] snapshot, error in
-//                guard let self, let data = snapshot?.data(),
-//                      let mateCount = data[self.mateUID] as? Int else { return }
-//                self.mateCountRelay.accept(mateCount)
-//            }
-//    }
     private func observeMateCount() {
         db.collection("matches")
             .document(matchCode)

--- a/FitMate/FitMate/Scene/JumpRope/JumpRopeCoop/ViewModel/JumpRopeCoopViewModel.swift
+++ b/FitMate/FitMate/Scene/JumpRope/JumpRopeCoop/ViewModel/JumpRopeCoopViewModel.swift
@@ -221,7 +221,7 @@ final class JumpRopeCoopViewModel: ViewModelType {
                 self.mateCountRelay.accept(progress)
                 
                 if progress >= self.goalCount {
-                    self.finish(success: false)
+                    self.finish(success: true)
                 }
             }
     }


### PR DESCRIPTION
close #240 
<!-- close #No(이슈 넘버 등록하면 자동으로 이슈가 닫힙니다. 이슈를 닫고 싶지 않다면, 즉 해당 이슈의 작업이 아직 끝나지 않았다면 닫지 않습니다.) -->

## *⛳️ Work Description*

<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

### 줄넘기 대결모드 승패 바뀌어서 저장되는 버그 픽스
#### 변경 전
- 대결의 승패를 하드코딩된 값을 가져와서 판단
#### 변경 후
- Firestore에 저장된 `isWinner` 값을 보고 승패를 판단하도록 변경

## *📸 Screenshot*
### 변경 전
- 메이트가 100회를 했지만 승리 했다고 나옴
![image](https://github.com/user-attachments/assets/eaea64f2-6f49-4801-98a3-b0f9e27e1053)
### 변경 후
- 메이트가 목표달성하여, 패배 라고 나옴
![image](https://github.com/user-attachments/assets/71badc99-9e1d-4cb0-894d-4ebe9ee65358)

<!-- 구현한 부분의 시뮬레이터 스크린샷을 올려주시면 됩니다. -->
<!-- 기기대응을 위해 사이즈가 다른 기기별로 스크린샷을 올리기도 합니다. -->
<!-- 움직이는 동작일 경우, 시뮬레이터 영상을 녹화하고 gif로 저장하여 드래그 앤 드롭을 통해 업로드하면 됩니다. -->

## *📢 To Reviewers*

<!-- 이 PR을 리뷰하는 사람들에게 할 말이 있다면 작성하시면 됩니다. -->

- 코드리뷰 부탁드립니다.

## *✅ Checklist*

<!-- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다. -->

- [x]  주석 및 프린트문 제거 확인.
- [x]  컨벤션 준수 확인.
