### PR TITLE
[Fix] #246 FCM토큰 저장 위치 변경

### DIFF
--- a/FitMate/FitMate/Scene/Login/ViewModel/LoginViewModel.swift
+++ b/FitMate/FitMate/Scene/Login/ViewModel/LoginViewModel.swift
@@ -54,6 +54,9 @@ final class LoginViewModel {
                     return FirestoreService.shared
                         .fetchDocument(collectionName: "users", documentName: uid) // 사용자 문서 검색
                         .flatMap { data -> Single<LoginNavigation> in
+                            if let token = Messaging.messaging().fcmToken {
+                                AppDelegate.saveFCMToken(token)
+                            }
                             // 닉네임이 있고
                             if let nickname = data["nickname"] as? String,
                                !nickname.isEmpty {
@@ -161,6 +164,9 @@ final class LoginViewModel {
                     return FirestoreService.shared
                         .fetchDocument(collectionName: "users", documentName: uid)
                         .flatMap { data -> Single<LoginNavigation> in
+                            if let token = Messaging.messaging().fcmToken {
+                                AppDelegate.saveFCMToken(token)
+                            }
                             // 닉네임 존재 여부 판단
                             if let nickname = data["nickname"] as? String,
                                !nickname.isEmpty {
@@ -210,6 +216,9 @@ final class LoginViewModel {
                     return FirestoreService.shared
                         .fetchDocument(collectionName: "users", documentName: uid)
                         .flatMap { data -> Single<LoginNavigation> in
+                            if let token = Messaging.messaging().fcmToken {
+                                AppDelegate.saveFCMToken(token)
+                            }
                             if let nickname = data["nickname"] as? String, !nickname.isEmpty {
                                 if let mate = data["hasMate"] as? Bool, mate == true {
                                     return .just(.goToMainViewController(uid: uid))


### PR DESCRIPTION
close #246

## *⛳️ Work Description*

- 기존에는 FCM토큰 저장이 유저 정보가 없을 때 (유저 문서 처음 생길 때)만 저장이 되었음
-  유저 정보가 남아있던 없던 둘 다 저장하는 방식으로 변경

## *📸 Screenshot*
- 스크린샷 필요 없어용

## *📢 To Reviewers*

- 코드리뷰 부탁드립니다.

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거 확인.
- [ ]  컨벤션 준수 확인.
