### PR TITLE
[Feat] #249 권한 요청 거부 후 취소 버튼 클릭시 matchStatus 상태 변경

### DIFF
--- a/FitMate/FitMate.xcodeproj/project.pbxproj
+++ b/FitMate/FitMate.xcodeproj/project.pbxproj
@@ -228,7 +228,7 @@
 				CODE_SIGN_ENTITLEMENTS = FitMate/FitMate.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 352FSM3VWQ;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -242,7 +242,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.hansarang.FitMate;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -267,7 +267,7 @@
 				CODE_SIGN_ENTITLEMENTS = FitMate/FitMate.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 352FSM3VWQ;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -281,7 +281,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.hansarang.FitMate;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/FitMate/FitMate/Common/Service/Firebase/Firestore/FirestoreService.swift
+++ b/FitMate/FitMate/Common/Service/Firebase/Firestore/FirestoreService.swift
@@ -909,3 +909,21 @@ extension FirestoreService {
         return df
     }()
 }
+
+// matches의 matchStatus 상태 변경
+// 로케이션 권한 요청 거절 후 취소 눌렀을 때 사용
+extension FirestoreService {
+    func updateMatchStatus(matchCode: String, status: String) -> Completable {
+        let docRef = db.collection("matches").document(matchCode)
+        return Completable.create { completable in
+            docRef.updateData(["matchStatus": status]) { error in
+                if let error = error {
+                    completable(.error(error))
+                } else {
+                    completable(.completed)
+                }
+            }
+            return Disposables.create()
+        }
+    }
+}

--- a/FitMate/FitMate/Scene/Running/RunningBattle/View/RunningBattleViewController.swift
+++ b/FitMate/FitMate/Scene/Running/RunningBattle/View/RunningBattleViewController.swift
@@ -182,9 +182,23 @@ class RunningBattleViewController: BaseViewController {
             }
         }))
 
-        alert.addAction(UIAlertAction(title: "취소", style: .cancel))
+        alert.addAction(UIAlertAction(title: "취소", style: .cancel, handler: { [weak self] _ in
+            guard let self = self else { return }
+            FirestoreService.shared
+                .updateMatchStatus(matchCode: self.matchCode, status: "cancelLocation")
+                .subscribe(
+                    onCompleted: {
+                        print("matchStatus: cancelLocation 저장 완료")
+                    },
+                    onError: { error in
+                        print("matchStatus 업데이트 실패: \(error.localizedDescription)")
+                    }
+                )
+                .disposed(by: self.disposeBag)
+        }))
 
         present(alert, animated: true)
     }
+
 
 }

--- a/FitMate/FitMate/Scene/Running/RunningCoop/View/RunningCoopViewController.swift
+++ b/FitMate/FitMate/Scene/Running/RunningCoop/View/RunningCoopViewController.swift
@@ -217,7 +217,20 @@ final class RunningCoopViewController: BaseViewController {
             }
         }))
 
-        alert.addAction(UIAlertAction(title: "취소", style: .cancel))
+        alert.addAction(UIAlertAction(title: "취소", style: .cancel, handler: { [weak self] _ in
+            guard let self = self else { return }
+            FirestoreService.shared
+                .updateMatchStatus(matchCode: self.matchCode, status: "cancelLocation")
+                .subscribe(
+                    onCompleted: {
+                        print("matchStatus: cancelLocation 저장 완료")
+                    },
+                    onError: { error in
+                        print("matchStatus 업데이트 실패: \(error.localizedDescription)")
+                    }
+                )
+                .disposed(by: self.disposeBag)
+        }))
 
         present(alert, animated: true)
     }


### PR DESCRIPTION
close #249

## *⛳️ Work Description*

- 권한 요청 거부 후 취소 버튼 클릭시 matchStatus 상태 변경
- matches 컬렉션의 matchStatus 상태값을 cancelLocation로 변경

## *📸 Screenshot*
- 스크린샷 필요 없는 이슈입니다.

## *📢 To Reviewers*

- 코드리뷰 부탁드립니다.

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거 확인.
- [ ]  컨벤션 준수 확인.
