### PR TITLE
[Fix] #272 메이트 초대 배너알림 메이트의 닉네임으로 수정

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -87,13 +87,14 @@ export const notifyInvitedUser = onDocumentUpdated(
     }
 
     const inviterUid = after?.fromUid as string|undefined;
-    const nickname = after?.nickname ?? "메이트";
+    const inviterDoc = await db.doc(`users/${inviterUid}`).get();
+    const inviterNickname = inviterDoc.get("nickname") ?? "메이트";
 
     const message = {
       token: fcmToken,
       notification: {
         title: "메이트 초대 도착!",
-        body: `${nickname}님이 메이트 초대를 보냈어요. 지금 확인해보세요.`,
+        body: `${inviterNickname}님이 메이트 초대를 보냈어요. 지금 확인해보세요.`,
       },
       data: {
         type: "friend_invitation",


### PR DESCRIPTION
close #272

## *⛳️ Work Description*

- 메이트 초대 알림이 보낸 사람이 아니라 받은 사람으로 표기되는 오류
- 보낸 사람 닉네임으로 수정함

## *📸 Screenshot*


## *📢 To Reviewers*

- 코드리뷰 부탁드립니다.

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거 확인.
- [ ]  컨벤션 준수 확인.
