### PR TITLE
[Fix] #273 초대코드 잘못 입력 시, 알림창 버튼 안눌림 버그 픽스

### DIFF
--- a/FitMate/FitMate/Common/Components/CustomAlertViewController.swift
+++ b/FitMate/FitMate/Common/Components/CustomAlertViewController.swift
@@ -18,7 +18,7 @@ final class CustomAlertViewController: UIViewController {
     var onCancel: (() -> Void)?
     
     private let alertType: CustomAlertType
-    private let cancelButton: UIButton = {
+    private lazy var cancelButton: UIButton = {
         let cancel = UIButton()
         cancel.titleLabel?.font = UIFont(name: "Pretendard-Regular", size: 18)
         cancel.setTitleColor(.background500, for: .normal)
@@ -27,7 +27,7 @@ final class CustomAlertViewController: UIViewController {
         cancel.addTarget(self, action: #selector(didTapCancel), for: .touchUpInside)
         return cancel
     }()
-    private let confirmButton: UIButton = {
+    private lazy var confirmButton: UIButton = {
         let confirm = UIButton()
         confirm.titleLabel?.font = UIFont(name: "Pretendard-Regular", size: 18)
         confirm.setTitleColor(.white, for: .normal)
@@ -101,15 +101,21 @@ final class CustomAlertViewController: UIViewController {
     }
     
     @objc private func didTapCancel() {
+        //print("🔵 [취소 버튼 탭]")
+        
         dismiss(animated: true) { [weak self] in
+            //print("🔵 [Alert 닫힘 - 취소]")
             self?.onCancel?()
         }
     }
     
     @objc private func didTapConfirm() {
+        //print("🟢 [확인 버튼 탭] alertType: \(alertType)")
         switch alertType {
         case .mateRequest(let uid):
+            //print("🟢 [mateRequest alert] -> CodeShareViewController 이동")
             dismiss(animated: true) { [weak self] in
+                //print("🟢 [Alert 닫힘 - mateRequest]")
                 self?.onConfirm?()
                 guard let presentingVC = self?.presentingViewController else { return }
                 let codeShareVC = CodeShareViewController(uid: uid, hasMate: false)
@@ -120,7 +126,9 @@ final class CustomAlertViewController: UIViewController {
             
         case .inviteSent, .requestFailed, .rejectRequest, .sportsMateRequest, .alreadyCancel, .matchingFail:
             // 확인만 누르면 dismiss
+            //print("🟢 [일반 확인 alert] → dismiss 진행")
             dismiss(animated: true) { [weak self] in
+                //print("🟢 [Alert 닫힘 - 일반 확인]")
                 self?.onConfirm?()
             }
             

--- a/FitMate/FitMate/Scene/CodeShare/View/MateCodeViewController.swift
+++ b/FitMate/FitMate/Scene/CodeShare/View/MateCodeViewController.swift
@@ -112,6 +112,7 @@ final class MateCodeViewController: BaseViewController {
     // MARK: - Alert
     /// ViewModel이 방출한 AlertType 에 따라 알림창 구성 및 출력
     private func presentAlert(for alert: CustomAlertType) {
+        //print("🟡 [Alert 호출] 타입: \(alert)") // ✅ 로그 추가
         //        let customType: CustomAlertType
         switch alert {
         case .inviteSent,
@@ -120,6 +121,15 @@ final class MateCodeViewController: BaseViewController {
              .rejectRequest:
             
             let alertVC = CustomAlertViewController(alertType: alert)
+            
+            // 확인/취소 콜백 로그
+            alertVC.onConfirm = {
+                //print("🟢 [Alert 확인 버튼 콜백 실행됨]")
+            }
+            alertVC.onCancel = {
+                //print("🔵 [Alert 취소 버튼 콜백 실행됨]")
+            }
+            
             self.present(alertVC, animated: true)
             
         default:


### PR DESCRIPTION
close #273 
<!-- close #No(이슈 넘버 등록하면 자동으로 이슈가 닫힙니다. 이슈를 닫고 싶지 않다면, 즉 해당 이슈의 작업이 아직 끝나지 않았다면 닫지 않습니다.) -->

## *⛳️ Work Description*

<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- 초대코드 잘못 입력 시, 알림창 버튼 안눌림 버그 픽스

## *📸 Screenshot*
![Simulator Screen Recording - iPhone 16 Pro Max - 2025-06-27 at 15 53 15](https://github.com/user-attachments/assets/1d5c4aed-4b3b-4bd5-9abb-6b006fc1d096)

<!-- 구현한 부분의 시뮬레이터 스크린샷을 올려주시면 됩니다. -->
<!-- 기기대응을 위해 사이즈가 다른 기기별로 스크린샷을 올리기도 합니다. -->
<!-- 움직이는 동작일 경우, 시뮬레이터 영상을 녹화하고 gif로 저장하여 드래그 앤 드롭을 통해 업로드하면 됩니다. -->

## *📢 To Reviewers*

<!-- 이 PR을 리뷰하는 사람들에게 할 말이 있다면 작성하시면 됩니다. -->

- 코드리뷰 부탁드립니다.

## *✅ Checklist*

<!-- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다. -->

- [x]  주석 및 프린트문 제거 확인.
- [x]  컨벤션 준수 확인.
