### PR TITLE
[Fix] #293 승/패 뒤바뀌어서 저장되는 로직 버그 픽스

### DIFF
--- a/FitMate/FitMate/Scene/Finish/View/FinishViewController.swift
+++ b/FitMate/FitMate/Scene/Finish/View/FinishViewController.swift
@@ -10,14 +10,14 @@ class FinishViewController: BaseViewController {
     let uid: String
     let mateUid: String
     let matchCode: String
-
+    
     init(uid: String, mateUid: String, matchCode: String, viewModel: FinishViewModel) {
         self.uid = uid
         self.mateUid = mateUid
         self.matchCode = matchCode
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
-       }
+    }
     
     required init?(coder: NSCoder) { fatalError("not implemented") }
     
@@ -68,27 +68,11 @@ class FinishViewController: BaseViewController {
             .drive(onNext: { [weak self] name in self?.finishView.updateCharacter(name) })
             .disposed(by: disposeBag)
         
-        
-//        finishView.rewardButton.rx.tap
-//            .bind { [weak self] in
-//                guard let self else { return }
-//                let tabBarVC = TabBarController(uid: self.uid)
-//                       tabBarVC.modalPresentationStyle = .fullScreen
-//                // rootViewController를 통째로 교체
-//                if let window = UIApplication.shared.connectedScenes
-//                    .compactMap({ ($0 as? UIWindowScene)?.keyWindow })
-//                    .first {
-//                    window.rootViewController = tabBarVC
-//                    window.makeKeyAndVisible()
-//                }
-//            }
-//            .disposed(by: disposeBag)
-        
         // 게임 결과 저장
         finishView.rewardButton.rx.tap
             .bind { [weak self] in
                 guard let self else { return }
-
+                
                 FirestoreService.shared.updateMatchResult(
                     matchCode: self.matchCode,
                     myUid: self.uid,
@@ -108,7 +92,7 @@ class FinishViewController: BaseViewController {
                 )
                 .subscribe(onCompleted: {
                     print("✅ 유저 기록 저장 완료")
-
+                    
                     let tabBarVC = TabBarController(uid: self.uid)
                     tabBarVC.modalPresentationStyle = .fullScreen
                     if let window = UIApplication.shared.connectedScenes

--- a/FitMate/FitMate/Scene/Finish/ViewModel/FinishViewModel.swift
+++ b/FitMate/FitMate/Scene/Finish/ViewModel/FinishViewModel.swift
@@ -135,13 +135,12 @@ extension FinishViewModel {
                 return .error(NSError(domain: "", code: -2, userInfo: [NSLocalizedDescriptionKey: "필드 누락 또는 변환 실패"]))
             }
 
-            let isWinner = data["isWinner"] as? Bool ?? false
+            let myIsWinner = myData["isWinner"] as? Bool ?? false
+
             let result: ExerciseResult = {
                 switch self.mode {
                 case .battle:
-                    return (isWinner && uid == data["inviterUid"] as? String) ||
-                           (!isWinner && uid == data["inviteeUid"] as? String)
-                        ? .versusWin : .versusLose
+                    return myIsWinner ? .versusWin : .versusLose
                 case .cooperation:
                     return self.success ? .teamSuccess : .teamFail
                 }

--- a/FitMate/FitMate/Scene/Finish/ViewModel/FinishViewModel.swift
+++ b/FitMate/FitMate/Scene/Finish/ViewModel/FinishViewModel.swift
@@ -128,10 +128,8 @@ extension FinishViewModel {
                   let players = data["players"] as? [String: Any],
                   let myData = players[uid] as? [String: Any],
                   let mateData = players[mateUid] as? [String: Any],
-//                  let myProgress = myData["progress"] as? Int,
-//                  let mateProgress = mateData["progress"] as? Int else {
-                    let myProgress = myData["progress"] as? Double,
-                    let mateProgress = mateData["progress"] as? Double else {
+                  let myProgress = myData["progress"] as? Double,
+                  let mateProgress = mateData["progress"] as? Double else {
                 return .error(NSError(domain: "", code: -2, userInfo: [NSLocalizedDescriptionKey: "필드 누락 또는 변환 실패"]))
             }
 
@@ -146,14 +144,6 @@ extension FinishViewModel {
                 }
             }()
 
-//            let record = ExerciseRecord(
-//                type: exerciseType,
-//                date: self.formatDate(timestamp.dateValue()),
-//                result: result,
-//                detail1: "\(goalValue)",
-//                detail2: "\(myProgress)",
-//                detail3: "\(mateProgress)"
-//            )
             let detail2: String
             let detail3: String
 

--- a/FitMate/FitMate/Scene/Running/RunningBattle/View/RunningBattleViewController.swift
+++ b/FitMate/FitMate/Scene/Running/RunningBattle/View/RunningBattleViewController.swift
@@ -3,6 +3,7 @@ import UIKit
 import Foundation
 import RxCocoa
 import CoreLocation
+import FirebaseFirestore
 
 class RunningBattleViewController: BaseViewController {
     
@@ -179,13 +180,47 @@ class RunningBattleViewController: BaseViewController {
         present(vc, animated: true)
     }
     
+    private func navigateToFinish() {
+        Firestore.firestore().collection("matches").document(matchCode)
+            .getDocument { [weak self] snapshot, error in
+                guard let self = self else { return }
+                guard let data = snapshot?.data(),
+                      let players = data["players"] as? [String: Any],
+                      let myData = players[self.myUid] as? [String: Any],
+                      let isWinner = myData["isWinner"] as? Bool else {
+                    print("승자 정보 불러오기 실패")
+                    return
+                }
+                
+                let finishVM = FinishViewModel(
+                    mode: .battle,
+                    sport: exerciseType,
+                    goal: goalDistance,
+                    goalUnit: "Km",
+                    myDistance: self.viewModel.myDistanceRelay.value,
+                    character: self.myCharacter,
+                    success: isWinner  // Firestore에서 가져온 최종 결과
+                )
+                
+                let vc = FinishViewController(
+                    uid: self.myUid,
+                    mateUid: self.mateUid,
+                    matchCode: self.matchCode,
+                    viewModel: finishVM
+                )
+                vc.modalPresentationStyle = .fullScreen
+                self.present(vc, animated: true)
+            }
+    }
+    
     func receiveMateQuit() {
         viewModel.stopLocationUpdates()
         rootView.showQuitAlert(
             type: .mateQuit,
             onBack: { [weak self] in
                 self?.viewModel.finish(success: true)
-                self?.navigateToFinish(success: true, myDistance: self?.viewModel.myDistanceRelay.value ?? 0.0)
+                //self?.navigateToFinish(success: true, myDistance: self?.viewModel.myDistanceRelay.value ?? 0.0)
+                self?.navigateToFinish()
             }
         )
     }


### PR DESCRIPTION
close #293 
<!-- close #No(이슈 넘버 등록하면 자동으로 이슈가 닫힙니다. 이슈를 닫고 싶지 않다면, 즉 해당 이슈의 작업이 아직 끝나지 않았다면 닫지 않습니다.) -->

## *⛳️ Work Description*

<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

### 걷기 / 달리기 / 자전거 승패가 뒤바껴 저장되는 현상 수정
- 승자 여부를 저장하는 `isWinner` 필드를 참고하여 승패를 저장하도록 수정

## *📸 Screenshot*
<img width="328" alt="image" src="https://github.com/user-attachments/assets/1d30654d-4c0e-4327-926f-114fc8442580" />

<!-- 구현한 부분의 시뮬레이터 스크린샷을 올려주시면 됩니다. -->
<!-- 기기대응을 위해 사이즈가 다른 기기별로 스크린샷을 올리기도 합니다. -->
<!-- 움직이는 동작일 경우, 시뮬레이터 영상을 녹화하고 gif로 저장하여 드래그 앤 드롭을 통해 업로드하면 됩니다. -->

## *📢 To Reviewers*

<!-- 이 PR을 리뷰하는 사람들에게 할 말이 있다면 작성하시면 됩니다. -->

- 코드리뷰 부탁드립니다.

## *✅ Checklist*

<!-- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다. -->

- [x]  주석 및 프린트문 제거 확인.
- [x]  컨벤션 준수 확인.
