### PR TITLE
[Fix] #291 구글 계정 탈퇴 시, 세션정보 nil 에러 수정

### DIFF
--- a/FitMate/FitMate/Common/Service/Firebase/Auth/AuthService.swift
+++ b/FitMate/FitMate/Common/Service/Firebase/Auth/AuthService.swift
@@ -284,42 +284,54 @@ final class AuthService: NSObject {
                 )))
                 return Disposables.create()
             }
-            
-            guard let googleUser = GIDSignIn.sharedInstance.currentUser else {
-                single(.failure(NSError(
-                    domain: "GoogleAuth",
-                    code: -2,
-                    userInfo: [NSLocalizedDescriptionKey: "Google 사용자 정보 없음"]
-                )))
-                return Disposables.create()
-            }
 
-            let idToken = googleUser.idToken?.tokenString
-            let accessToken = googleUser.accessToken.tokenString
-
-            guard let idToken, !idToken.isEmpty else {
-                single(.failure(NSError(
-                    domain: "GoogleAuth",
-                    code: -3,
-                    userInfo: [NSLocalizedDescriptionKey: "idToken 없음"]
-                )))
-                return Disposables.create()
-            }
-
-            let credential = GoogleAuthProvider.credential(withIDToken: idToken, accessToken: accessToken)
-
-            user.reauthenticate(with: credential) { _, error in
-                if let error = error {
-                    single(.failure(error))
-                } else {
-                    single(.success(()))
+            // 세션 복원 먼저 시도
+            if GIDSignIn.sharedInstance.currentUser == nil {
+                GIDSignIn.sharedInstance.restorePreviousSignIn { restoredUser, error in
+                    if let restoredUser = restoredUser {
+                        print("🔁 구글 세션 복원 성공")
+                        self.performGoogleReauth(user: user, googleUser: restoredUser, single: single)
+                    } else {
+                        single(.failure(NSError(
+                            domain: "GoogleAuth",
+                            code: -99,
+                            userInfo: [NSLocalizedDescriptionKey: "Google 세션 복원 실패: \(error?.localizedDescription ?? "알 수 없음")"]
+                        )))
+                    }
                 }
+            } else {
+                // 세션 이미 살아있으면 바로 재인증 시도
+                let googleUser = GIDSignIn.sharedInstance.currentUser!
+                self.performGoogleReauth(user: user, googleUser: googleUser, single: single)
             }
 
             return Disposables.create()
         }
     }
     
+    private func performGoogleReauth(user: FirebaseAuth.User, googleUser: GIDGoogleUser, single: @escaping (SingleEvent<Void>) -> Void) {
+        guard let idToken = googleUser.idToken?.tokenString else {
+            single(.failure(NSError(
+                domain: "GoogleAuth",
+                code: -3,
+                userInfo: [NSLocalizedDescriptionKey: "idToken 없음"]
+            )))
+            return
+        }
+
+        let accessToken = googleUser.accessToken.tokenString
+        let credential = GoogleAuthProvider.credential(withIDToken: idToken, accessToken: accessToken)
+
+        user.reauthenticate(with: credential) { _, error in
+            if let error = error {
+                single(.failure(error))
+            } else {
+                single(.success(()))
+            }
+        }
+    }
+    
+    // MARK: 카카오 재인증
     func reauthenticateKakaoUser(kakaoUser: KakaoUser) -> Single<Void> {
         return Single.create { single in
             guard let user = Auth.auth().currentUser else {


### PR DESCRIPTION
close #291 
<!-- close #No(이슈 넘버 등록하면 자동으로 이슈가 닫힙니다. 이슈를 닫고 싶지 않다면, 즉 해당 이슈의 작업이 아직 끝나지 않았다면 닫지 않습니다.) -->

## *⛳️ Work Description*

<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
### 회원탈퇴 시, 세션 복원 로직 추가
- 회원탈퇴 시, 로그인 정보가 저장된 세션을 확인 함.
- 확인 과정에서 로그인 정보가 저장된 세션이 `nil` 이 나오게 되면 회원탈퇴가 진행 안됨.
- 따라서 회원탈퇴 시, 세션 복원 로직 수행하여 해당 오류를 해소함.

## *📸 Screenshot*
- 스크린샷이 제공 불가.
<!-- 구현한 부분의 시뮬레이터 스크린샷을 올려주시면 됩니다. -->
<!-- 기기대응을 위해 사이즈가 다른 기기별로 스크린샷을 올리기도 합니다. -->
<!-- 움직이는 동작일 경우, 시뮬레이터 영상을 녹화하고 gif로 저장하여 드래그 앤 드롭을 통해 업로드하면 됩니다. -->

## *📢 To Reviewers*

<!-- 이 PR을 리뷰하는 사람들에게 할 말이 있다면 작성하시면 됩니다. -->

- 코드리뷰 부탁드립니다.

## *✅ Checklist*

<!-- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다. -->

- [x]  주석 및 프린트문 제거 확인.
- [x]  컨벤션 준수 확인.
