### PR TITLE
[Fix] #292 로그인 취소 시, alert 창 안나오게 수정

### DIFF
--- a/FitMate/FitMate/Scene/Login/View/LoginViewController.swift
+++ b/FitMate/FitMate/Scene/Login/View/LoginViewController.swift
@@ -104,9 +104,9 @@ class LoginViewController: BaseViewController {
                     let vc = NicknameViewController(uid: uid)
                     self.navigationController?.pushViewController(vc, animated: true)
 
-                case .error(let msg):
+                case .error:
                     // 에러 발생 시 메시지 띄우기
-                    self.showErrorAlert(message: msg)
+                    print("로그인이 취소됨")
                 }
             }).disposed(by: disposeBag)
         


### PR DESCRIPTION
close #292 
<!-- close #No(이슈 넘버 등록하면 자동으로 이슈가 닫힙니다. 이슈를 닫고 싶지 않다면, 즉 해당 이슈의 작업이 아직 끝나지 않았다면 닫지 않습니다.) -->

## *⛳️ Work Description*

<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- 로그인 취소 시, Alert 창이 뜨지 않음

## *📸 Screenshot*
![Simulator Screen Recording - iPhone 16 Pro Max - 2025-07-01 at 15 52 11](https://github.com/user-attachments/assets/08f69a7b-80dc-409f-8af3-bfbcdbd2827e)

<!-- 구현한 부분의 시뮬레이터 스크린샷을 올려주시면 됩니다. -->
<!-- 기기대응을 위해 사이즈가 다른 기기별로 스크린샷을 올리기도 합니다. -->
<!-- 움직이는 동작일 경우, 시뮬레이터 영상을 녹화하고 gif로 저장하여 드래그 앤 드롭을 통해 업로드하면 됩니다. -->

## *📢 To Reviewers*

<!-- 이 PR을 리뷰하는 사람들에게 할 말이 있다면 작성하시면 됩니다. -->

- 코드리뷰 부탁드립니다.

## *✅ Checklist*

<!-- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다. -->

- [x]  주석 및 프린트문 제거 확인.
- [x]  컨벤션 준수 확인.
