### PR TITLE
Feat/#309 운동화면에도 아바타 반영 로직 추가, 아바타 구매 시 메인 화면 아바타 연동 오류 개선

### DIFF
--- a/FitMate/FitMate/Common/Components/AvatarManager.swift
+++ b/FitMate/FitMate/Common/Components/AvatarManager.swift
@@ -18,7 +18,11 @@ final class AvatarManager {
 
     /// 현재 선택된 아바타 (Firestore 저장 포함된 모델이면 AvatarModel도 가능)
     let selectedAvatarRelay = BehaviorRelay<AvatarType?>(value: nil)
+    var mateAvatarRelay = BehaviorRelay<AvatarType?>(value: nil)
+    private var previousMateAvatarType: AvatarType?
 
+    
+    private var disposeBag = DisposeBag()
     private init() { }
 
     /// Firestore에서 현재 유저의 아바타 불러오기
@@ -31,10 +35,23 @@ final class AvatarManager {
     }
 
     /// 새로 선택한 아바타 저장과 반영
-    func updateAvatar(uid: String, avatarType: AvatarType, mateUid: String?) {
-        FirestoreService.shared.saveSelectedAvatar(uid: uid, type: avatarType, mateUid: mateUid)
+    func updateAvatar(uid: String, avatarType: AvatarType) {
+        FirestoreService.shared.saveSelectedAvatar(uid: uid, type: avatarType)
         selectedAvatarRelay.accept(avatarType)
     }
+    
+    /// 메이트 아바타 Firestore에서 fetch해서 반영
+    func fetchMateAvatar(uid: String) {
+        FirestoreService.shared.loadSelectedAvatar(uid: uid)
+            .subscribe(onSuccess: { [weak self] avatarType in
+                guard let self else { return }
 
-    private let disposeBag = DisposeBag()
+                // 이전 값과 비교해서 다를 때만 relay 갱신
+                if avatarType != self.previousMateAvatarType {
+                    self.previousMateAvatarType = avatarType
+                    self.mateAvatarRelay.accept(avatarType)
+                }
+            })
+            .disposed(by: disposeBag)
+    }
 }

--- a/FitMate/FitMate/Common/Service/Firebase/Firestore/FirestoreService.swift
+++ b/FitMate/FitMate/Common/Service/Firebase/Firestore/FirestoreService.swift
@@ -405,22 +405,12 @@ class FirestoreService {
     /// 사용자가 선택한 대표 아바타를 Firestore에 저장하는 메서드
     /// uid ->  로그인된 사용자 UID
     /// avatarImageName ->  저장할 아바타 타입의 rawValue
-    func saveSelectedAvatar(uid: String, type: AvatarType, mateUid: String?) {
+    func saveSelectedAvatar(uid: String, type: AvatarType) {
         let userRef = db.collection("users").document(uid)
-        
-        var data: [String: Any] = [
+        let data: [String: Any] = [
             "avatarType": type.rawValue
         ]
-        
         userRef.setData(data, merge: true)
-        
-        // 메이트에게도 내 아바타 반영
-        if let mateUid = mateUid {
-            let mateRef = db.collection("users").document(mateUid)
-            mateRef.setData([
-                "mate.avatarType": type.rawValue
-            ], merge: true)
-        }
     }
     
     /// Firestore에 저장된 사용자의 선택 아바타를 불러오는 메서드

--- a/FitMate/FitMate/Scene/Finish/ViewModel/FinishViewModel.swift
+++ b/FitMate/FitMate/Scene/Finish/ViewModel/FinishViewModel.swift
@@ -26,16 +26,16 @@ final class FinishViewModel: ViewModelType {
     let goal: Int
     private let goalUnit: String
     let myDistance: Double
-    private let character: String
     let success: Bool
+    let avatarType: AvatarType
 
-    init(mode: Mode, sport: String, goal: Int, goalUnit: String, myDistance: Double = 0.0, character: String, success: Bool) {
+    init(mode: Mode, sport: String, goal: Int, goalUnit: String, myDistance: Double = 0.0, avatarType: AvatarType, success: Bool) {
         self.mode = mode
         self.sport = sport
         self.goal = goal
         self.goalUnit = goalUnit
         self.myDistance = myDistance      // 실제 달성 거리 (ex. 2.4)
-        self.character = character
+        self.avatarType = avatarType
         self.success = success
     }
 
@@ -47,7 +47,8 @@ final class FinishViewModel: ViewModelType {
         let myDistance: Double // 실제 달성 거리 (ex. 2.4Km)
         let result = Observable.just(resultMessage)
         let resultImage = Observable.just(success ? "win" : "Lose")
-        let characterImage = Observable.just(success ? character : "\(character)Lose")
+        let characterImage = Observable.just(success ? avatarType.rawValue : "\(avatarType.rawValue)Lose")
+
 
         return Output(
             modeText: modeText.asDriver(onErrorJustReturn: ""),

--- a/FitMate/FitMate/Scene/JumpRope/JumpRopeBattle/View/JumpRopeBattleViewController.swift
+++ b/FitMate/FitMate/Scene/JumpRope/JumpRopeBattle/View/JumpRopeBattleViewController.swift
@@ -22,6 +22,7 @@ class JumpRopeBattleViewController: BaseViewController {
     private let mateUid: String
     private let myUid: String
     
+    
     init(goalCount: Int, matchCode: String, myUid: String, mateUid: String,  myCharacter: String, mateCharacter: String) {
         self.matchCode = matchCode
         self.myUid = myUid
@@ -134,13 +135,15 @@ class JumpRopeBattleViewController: BaseViewController {
     
     // 피니쉬화면으로 이동
     private func navigateToFinish(success: Bool) {
+        let avatarType = AvatarType(rawValue: myCharacter) ?? .kaepy
+        
         let finishVM = FinishViewModel(
             mode: .battle,
             sport: "줄넘기",
             goal: viewModel.goalCount,
             goalUnit: "개",
             myDistance: Double(viewModel.myCount),
-            character: myCharacter,
+            avatarType: avatarType,
             success: success
         )
         
@@ -166,6 +169,8 @@ class JumpRopeBattleViewController: BaseViewController {
                     print("🔥 승자 정보 불러오기 실패")
                     return
                 }
+                
+                let avatarType = AvatarType(rawValue: self.myCharacter) ?? .kaepy
 
                 let finishVM = FinishViewModel(
                     mode: .battle,
@@ -173,7 +178,7 @@ class JumpRopeBattleViewController: BaseViewController {
                     goal: self.viewModel.goalCount,
                     goalUnit: "개",
                     myDistance: Double(self.viewModel.myCount),
-                    character: self.myCharacter,
+                    avatarType: avatarType,
                     success: isWinner  // ✅ Firestore에서 가져온 최종 결과
                 )
 

--- a/FitMate/FitMate/Scene/JumpRope/JumpRopeCoop/View/JumpRopeCoopViewController.swift
+++ b/FitMate/FitMate/Scene/JumpRope/JumpRopeCoop/View/JumpRopeCoopViewController.swift
@@ -118,13 +118,15 @@ class JumpRopeCoopViewController: BaseViewController {
     
     
     private func navigateToFinish(success: Bool) {
+        let avatarType = AvatarType(rawValue: self.myCharacter) ?? .kaepy
+        
         let finishVM = FinishViewModel(
             mode: .cooperation,
             sport: "줄넘기",
             goal: viewModel.goalCount,
             goalUnit: "개",
             myDistance: Double(viewModel.myCount),
-            character: myCharacter,
+            avatarType: avatarType,
             success: success
         )
         let vc = FinishViewController(uid: myUid,

--- a/FitMate/FitMate/Scene/Loading/View/LoadingViewController.swift
+++ b/FitMate/FitMate/Scene/Loading/View/LoadingViewController.swift
@@ -134,7 +134,7 @@ class LoadingViewController: BaseViewController {
                 }
                 return .just((inviterUid, inviteeUid, exerciseType, mode, goalValue))
             }
-            .flatMap { inviterUid, inviteeUid, exerciseType, mode, goalValue -> Single<(String, String, String, String, Int)> in
+            .flatMap { inviterUid, inviteeUid, exerciseType, mode, goalValue -> Single<(String, String, String, String, Int, String)> in
                 let mateUid = self.uid == inviterUid ? inviteeUid : inviterUid
 
                 // 내 아바타
@@ -146,37 +146,73 @@ class LoadingViewController: BaseViewController {
                 return FirestoreService.shared.loadSelectedAvatar(uid: mateUid)
                     .map { mateAvatarType in
                         let mateAvatarRaw = mateAvatarType?.rawValue ?? "kaepy" // fallback
-                        return (exerciseType, mode, myAvatarRaw, mateAvatarRaw, goalValue)
+                        return (exerciseType, mode, myAvatarRaw, mateAvatarRaw, goalValue, mateUid)
                     }
             }
             .observe(on: MainScheduler.instance)
-            .subscribe(onSuccess: { exerciseType, mode, myCharacter, mateCharacter, goalValue in
-
+            .subscribe(onSuccess: { exerciseType, mode, myCharacter, mateCharacter, goalValue, mateUid in
                 let matchCode = self.matchCode
                 let myUid = self.uid
-                let mateUid = (myUid == exerciseType) ? mode : "" // 이미 따로 계산했으므로 패스 가능
 
                 let pushVC: UIViewController?
 
                 if mode == "battle" {
                     switch exerciseType {
                     case "걷기", "달리기", "자전거":
-                        pushVC = RunningBattleViewController(exerciseType: exerciseType, goalDistance: goalValue, matchCode: matchCode, myUid: myUid, mateUid: mateUid, myCharacter: myCharacter, mateCharacter: mateCharacter)
+                        pushVC = RunningBattleViewController(
+                            exerciseType: exerciseType,
+                            goalDistance: goalValue,
+                            matchCode: matchCode,
+                            myUid: myUid,
+                            mateUid: mateUid,
+                            myCharacter: myCharacter,
+                            mateCharacter: mateCharacter
+                        )
                     case "줄넘기":
-                        pushVC = JumpRopeBattleViewController(goalCount: goalValue, matchCode: matchCode, myUid: myUid, mateUid: mateUid, myCharacter: myCharacter, mateCharacter: mateCharacter)
+                        pushVC = JumpRopeBattleViewController(
+                            goalCount: goalValue,
+                            matchCode: matchCode,
+                            myUid: myUid,
+                            mateUid: mateUid,
+                            myCharacter: myCharacter,
+                            mateCharacter: mateCharacter
+                        )
                     default: return
                     }
                 } else {
                     switch exerciseType {
                     case "걷기", "달리기", "자전거":
-                        pushVC = RunningCoopViewController(exerciseType: exerciseType, goalDistance: goalValue, matchCode: matchCode, myUid: myUid, mateUid: mateUid, myCharacter: myCharacter, mateCharacter: mateCharacter)
+                        pushVC = RunningCoopViewController(
+                            exerciseType: exerciseType,
+                            goalDistance: goalValue,
+                            matchCode: matchCode,
+                            myUid: myUid,
+                            mateUid: mateUid,
+                            myCharacter: myCharacter,
+                            mateCharacter: mateCharacter
+                        )
                     case "플랭크":
-                        pushVC = PlankCoopViewController(goalMinutes: goalValue, matchCode: matchCode, myUID: myUid, mateUID: mateUid, myCharacter: myCharacter, mateCharacter: mateCharacter)
+                        pushVC = PlankCoopViewController(
+                            goalMinutes: goalValue,
+                            matchCode: matchCode,
+                            myUID: myUid,
+                            mateUID: mateUid,
+                            myCharacter: myCharacter,
+                            mateCharacter: mateCharacter
+                        )
                     case "줄넘기":
-                        pushVC = JumpRopeCoopViewController(goalCount: goalValue, matchCode: matchCode, myUid: myUid, mateUid: mateUid, myCharacter: myCharacter, mateCharacter: mateCharacter)
+                        pushVC = JumpRopeCoopViewController(
+                            goalCount: goalValue,
+                            matchCode: matchCode,
+                            myUid: myUid,
+                            mateUid: mateUid,
+                            myCharacter: myCharacter,
+                            mateCharacter: mateCharacter
+                        )
                     default: return
                     }
                 }
+
                 if let vc = pushVC {
                     self.navigationController?.pushViewController(vc, animated: true)
                 }
@@ -185,6 +221,7 @@ class LoadingViewController: BaseViewController {
             })
             .disposed(by: disposeBag)
     }
+
     
     /// 운동 요청 거절 시, 띄워지는 알림창 메서드
     private func presentRejectedAlert(message: String) {

--- a/FitMate/FitMate/Scene/Loading/View/LoadingViewController.swift
+++ b/FitMate/FitMate/Scene/Loading/View/LoadingViewController.swift
@@ -123,60 +123,67 @@ class LoadingViewController: BaseViewController {
     
     /// 게임 화면으로 이동하는 메서드
     private func goToGameScreen() {
-        
-        // MARK: - 게임 선택에 따른 화면 분기처리
         FirestoreService.shared.fetchDocument(collectionName: "matches", documentName: self.matchCode)
-            .subscribe(onSuccess: { data in
-                if let goalValue = data["goalValue"] as? Int,
-                   let inviterUid = data["inviterUid"] as? String,
-                   let inviteeUid = data["inviteeUid"] as? String,
-                   let exerciseType = data["exerciseType"] as? String,
-                   let mode = data["mode"] as? String {
-                    
-                    let mateUid = self.uid == inviterUid ? inviteeUid : inviterUid
-                    
-                    if mode == "battle" {
-                        // 배틀모드
-                        switch exerciseType {
-                        case "걷기":
-                            self.navigationController?.pushViewController(RunningBattleViewController(exerciseType: exerciseType, goalDistance: goalValue, matchCode: self.matchCode, myUid: self.uid, mateUid: mateUid, myCharacter: "kaepy", mateCharacter: "kaepy"), animated: true)
-                        case "달리기":
-                            self.navigationController?.pushViewController(RunningBattleViewController(exerciseType: exerciseType, goalDistance: goalValue, matchCode: self.matchCode, myUid: self.uid, mateUid: mateUid, myCharacter: "kaepy", mateCharacter: "kaepy"), animated: true)
-                        case "자전거":
-                            self.navigationController?.pushViewController(RunningBattleViewController(exerciseType: exerciseType, goalDistance: goalValue, matchCode: self.matchCode, myUid: self.uid, mateUid: mateUid, myCharacter: "kaepy", mateCharacter: "kaepy"), animated: true)
-                        case "줄넘기":
-                            self.navigationController?.pushViewController(JumpRopeBattleViewController(goalCount: goalValue, matchCode: self.matchCode, myUid: self.uid, mateUid: mateUid, myCharacter: "kaepy", mateCharacter: "kaepy"), animated: true)
-                        default:
-                            return
-                        }
-                    } else {
-                        // 협동모드
-                        switch exerciseType {
-                        case "걷기":
-                            self.navigationController?.pushViewController(RunningCoopViewController(exerciseType: exerciseType, goalDistance: goalValue, matchCode: self.matchCode, myUid: self.uid, mateUid: mateUid, myCharacter: "kaepy", mateCharacter: "kaepy"), animated: true)
-                        case "달리기":
-                            self.navigationController?.pushViewController(RunningCoopViewController(exerciseType: exerciseType, goalDistance: goalValue, matchCode: self.matchCode, myUid: self.uid, mateUid: mateUid, myCharacter: "kaepy", mateCharacter: "kaepy"), animated: true)
-                        case "자전거":
-                            self.navigationController?.pushViewController(
-                                RunningCoopViewController(
-                                    exerciseType: exerciseType, 
-                                    goalDistance: goalValue,
-                                    matchCode: self.matchCode,
-                                    myUid: self.uid,
-                                    mateUid: mateUid,
-                                    myCharacter: "kaepy",
-                                    mateCharacter: "kaepy"
-                                ), animated: true)
-                        case "플랭크":
-                            self.navigationController?.pushViewController(PlankCoopViewController(goalMinutes: goalValue, matchCode: self.matchCode, myUID: self.uid, mateUID: mateUid, myCharacter: "kaepy", mateCharacter: "kaepy"), animated: true)
-                        case "줄넘기":
-                            self.navigationController?.pushViewController(JumpRopeCoopViewController(goalCount: goalValue, matchCode: self.matchCode, myUid: self.uid, mateUid: mateUid, myCharacter: "kaepy", mateCharacter: "kaepy"), animated: true)
-                        default:
-                            return
-                        }
+            .flatMap { data -> Single<(String, String, String, String, Int)> in
+                guard let goalValue = data["goalValue"] as? Int,
+                      let inviterUid = data["inviterUid"] as? String,
+                      let inviteeUid = data["inviteeUid"] as? String,
+                      let exerciseType = data["exerciseType"] as? String,
+                      let mode = data["mode"] as? String else {
+                    return .error(NSError(domain: "DataError", code: -1, userInfo: nil))
+                }
+                return .just((inviterUid, inviteeUid, exerciseType, mode, goalValue))
+            }
+            .flatMap { inviterUid, inviteeUid, exerciseType, mode, goalValue -> Single<(String, String, String, String, Int)> in
+                let mateUid = self.uid == inviterUid ? inviteeUid : inviterUid
+
+                // 내 아바타
+                guard let myAvatarRaw = AvatarManager.shared.selectedAvatarRelay.value?.rawValue else {
+                    return .error(NSError(domain: "AvatarError", code: -2, userInfo: [NSLocalizedDescriptionKey: "내 아바타 없음"]))
+                }
+
+                // 상대 아바타 불러오기
+                return FirestoreService.shared.loadSelectedAvatar(uid: mateUid)
+                    .map { mateAvatarType in
+                        let mateAvatarRaw = mateAvatarType?.rawValue ?? "kaepy" // fallback
+                        return (exerciseType, mode, myAvatarRaw, mateAvatarRaw, goalValue)
+                    }
+            }
+            .observe(on: MainScheduler.instance)
+            .subscribe(onSuccess: { exerciseType, mode, myCharacter, mateCharacter, goalValue in
+
+                let matchCode = self.matchCode
+                let myUid = self.uid
+                let mateUid = (myUid == exerciseType) ? mode : "" // 이미 따로 계산했으므로 패스 가능
+
+                let pushVC: UIViewController?
+
+                if mode == "battle" {
+                    switch exerciseType {
+                    case "걷기", "달리기", "자전거":
+                        pushVC = RunningBattleViewController(exerciseType: exerciseType, goalDistance: goalValue, matchCode: matchCode, myUid: myUid, mateUid: mateUid, myCharacter: myCharacter, mateCharacter: mateCharacter)
+                    case "줄넘기":
+                        pushVC = JumpRopeBattleViewController(goalCount: goalValue, matchCode: matchCode, myUid: myUid, mateUid: mateUid, myCharacter: myCharacter, mateCharacter: mateCharacter)
+                    default: return
+                    }
+                } else {
+                    switch exerciseType {
+                    case "걷기", "달리기", "자전거":
+                        pushVC = RunningCoopViewController(exerciseType: exerciseType, goalDistance: goalValue, matchCode: matchCode, myUid: myUid, mateUid: mateUid, myCharacter: myCharacter, mateCharacter: mateCharacter)
+                    case "플랭크":
+                        pushVC = PlankCoopViewController(goalMinutes: goalValue, matchCode: matchCode, myUID: myUid, mateUID: mateUid, myCharacter: myCharacter, mateCharacter: mateCharacter)
+                    case "줄넘기":
+                        pushVC = JumpRopeCoopViewController(goalCount: goalValue, matchCode: matchCode, myUid: myUid, mateUid: mateUid, myCharacter: myCharacter, mateCharacter: mateCharacter)
+                    default: return
                     }
                 }
-            }).disposed(by: disposeBag)
+                if let vc = pushVC {
+                    self.navigationController?.pushViewController(vc, animated: true)
+                }
+            }, onFailure: { error in
+                print("아바타 에러: \(error.localizedDescription)")
+            })
+            .disposed(by: disposeBag)
     }
     
     /// 운동 요청 거절 시, 띄워지는 알림창 메서드

--- a/FitMate/FitMate/Scene/Main/View/MainView.swift
+++ b/FitMate/FitMate/Scene/Main/View/MainView.swift
@@ -14,27 +14,27 @@ class MainView: BaseView {
         return view
     }()
 
-//    let coinLabel: UILabel = {
-//        let coin = UILabel()
-//        coin.text = "100"
-//        coin.font = UIFont(name: "DungGeunMo", size: 26)
-//        coin.textColor = .secondary400
-//        return coin
-//    }()
-//    
-//    let coinIcon: UIImageView = {
-//        let coinImg = UIImageView()
-//        coinImg.image = UIImage(named: "coin")
-//        coinImg.contentMode = .scaleAspectFit
-//        coinImg.clipsToBounds = true
-//        return coinImg
-//    }()
-//    
-//    let bellButton: UIButton = {
-//        let bell = UIButton()
-//        bell.setImage(UIImage(named: "bell"), for: .normal)
-//        return bell
-//    }()
+    let coinLabel: UILabel = {
+        let coin = UILabel()
+        coin.text = "100"
+        coin.font = UIFont(name: "DungGeunMo", size: 26)
+        coin.textColor = .secondary400
+        return coin
+    }()
+    
+    let coinIcon: UIImageView = {
+        let coinImg = UIImageView()
+        coinImg.image = UIImage(named: "coin")
+        coinImg.contentMode = .scaleAspectFit
+        coinImg.clipsToBounds = true
+        return coinImg
+    }()
+    
+    let bellButton: UIButton = {
+        let bell = UIButton()
+        bell.setImage(UIImage(named: "bell"), for: .normal)
+        return bell
+    }()
     
     let explainLabel: UILabel = {
         let explain = UILabel()
@@ -108,7 +108,7 @@ class MainView: BaseView {
             [topBar, explainLabel, dDaysLabel, myAvatarImage,
              mateAvatarImage, exerciseButton,
              myNicknameStack, mateNicknameStack].forEach { addSubview($0) }
-//        [coinLabel, coinIcon, bellButton].forEach({topBar.addSubview($0)})
+        [coinLabel, coinIcon, bellButton].forEach({topBar.addSubview($0)})
     }
     
     override func setLayoutUI() {
@@ -119,22 +119,22 @@ class MainView: BaseView {
             make.height.equalTo(56)
         }
         
-//        coinIcon.snp.makeConstraints { make in
-//            make.centerY.equalTo(topBar)
-//            make.leading.equalToSuperview().inset(20)
-//            make.size.equalTo(23)
-//        }
-//        
-//        coinLabel.snp.makeConstraints { make in
-//            make.centerY.equalTo(topBar)
-//            make.leading.equalTo(coinIcon.snp.trailing).offset(8)
-//        }
-//        
-//        bellButton.snp.makeConstraints{ make in
-//            make.centerY.equalTo(topBar)
-//            make.trailing.equalToSuperview().inset(20)
-//            make.size.equalTo(28)
-//        }
+        coinIcon.snp.makeConstraints { make in
+            make.centerY.equalTo(topBar)
+            make.leading.equalToSuperview().inset(20)
+            make.size.equalTo(23)
+        }
+        
+        coinLabel.snp.makeConstraints { make in
+            make.centerY.equalTo(topBar)
+            make.leading.equalTo(coinIcon.snp.trailing).offset(8)
+        }
+        
+        bellButton.snp.makeConstraints{ make in
+            make.centerY.equalTo(topBar)
+            make.trailing.equalToSuperview().inset(20)
+            make.size.equalTo(28)
+        }
         
         explainLabel.snp.makeConstraints { make in
             make.top.equalTo(topBar.snp.bottom).offset(18)

--- a/FitMate/FitMate/Scene/Main/View/MainViewController.swift
+++ b/FitMate/FitMate/Scene/Main/View/MainViewController.swift
@@ -43,10 +43,6 @@ class MainViewController: BaseViewController {
         navigationController?.setNavigationBarHidden(true, animated: false)
         fetchMateStatusAndUpdateUI()
         updateMyAvatarImage()
-        
-        if let mateUid = mateUid {
-            updateMateAvatarImage(mateUid: mateUid)
-        }
     }
     
     // 네비게이션 영역 다시 보여줌
@@ -191,6 +187,7 @@ class MainViewController: BaseViewController {
         let components = calendar.dateComponents([.day], from: start, to: today)
         return (components.day ?? 0) + 1 // 연결일도 포함해서 +1
     }
+    
     private func updateMyAvatarImage() {
         AvatarManager.shared.selectedAvatarRelay
             .compactMap { $0 }
@@ -207,17 +204,22 @@ class MainViewController: BaseViewController {
     }
     
     private func updateMateAvatarImage(mateUid: String) {
-        FirestoreService.shared.loadSelectedAvatar(uid: mateUid)
-            .subscribe(onSuccess: { [weak self] avatarType in
+        // 메이트 아바타 Firestore에서 불러와 relay에 반영
+        AvatarManager.shared.fetchMateAvatar(uid: mateUid)
+
+        // relay 값이 업데이트되면 이미지 갱신
+        AvatarManager.shared.mateAvatarRelay
+            .compactMap { $0 }
+            .distinctUntilChanged() // 같은 값은 무시
+            .observe(on: MainScheduler.instance)
+            .bind { [weak self] avatarType in
                 guard let self,
-                      let avatarType,
-                      let avatar = AvatarType.allCases.first(where: { $0 == avatarType }),
-                      let image = UIImage(named: avatar.imageName),
+                      let image = UIImage(named: avatarType.imageName),
                       let cgImage = image.cgImage else { return }
 
                 let fixed = UIImage(cgImage: cgImage, scale: image.scale, orientation: .up)
                 self.mainView.mateAvatarImage.image = fixed
-            })
+            }
             .disposed(by: disposeBag)
     }
 }

--- a/FitMate/FitMate/Scene/Plank/PlankCoop/View/PlankCoopViewController.swift
+++ b/FitMate/FitMate/Scene/Plank/PlankCoop/View/PlankCoopViewController.swift
@@ -194,12 +194,14 @@ final class PlankCoopViewController: BaseViewController {
             .disposed(by: disposeBag)
     }
     private func navigateToFinish(success: Bool) {
+        let avatarType = AvatarType(rawValue: self.myCharacter) ?? .kaepy
+
         let finishVM = FinishViewModel(
             mode: .cooperation,
             sport: "플랭크",
             goal: viewModel.goalMinutes,
             goalUnit: "분",
-            character: myCharacter,
+            avatarType: avatarType,
             success: success
         )
         let vc = FinishViewController(uid: myUID,

--- a/FitMate/FitMate/Scene/Running/RunningBattle/View/RunningBattleViewController.swift
+++ b/FitMate/FitMate/Scene/Running/RunningBattle/View/RunningBattleViewController.swift
@@ -161,13 +161,15 @@ class RunningBattleViewController: BaseViewController {
     }
     
     private func navigateToFinish(success: Bool, myDistance: Double) {
+        let avatarType = AvatarType(rawValue: self.myCharacter) ?? .kaepy
+        
         let finishVM = FinishViewModel(
             mode: .battle,
             sport: exerciseType,
             goal: goalDistance,
             goalUnit: "Km",
             myDistance: myDistance,
-            character: myCharacter,
+            avatarType: avatarType,
             success: success
         )
         let vc = FinishViewController(
@@ -191,6 +193,7 @@ class RunningBattleViewController: BaseViewController {
                     print("승자 정보 불러오기 실패")
                     return
                 }
+                let avatarType = AvatarType(rawValue: self.myCharacter) ?? .kaepy
                 
                 let finishVM = FinishViewModel(
                     mode: .battle,
@@ -198,7 +201,7 @@ class RunningBattleViewController: BaseViewController {
                     goal: goalDistance,
                     goalUnit: "Km",
                     myDistance: self.viewModel.myDistanceRelay.value,
-                    character: self.myCharacter,
+                    avatarType: avatarType,
                     success: isWinner  // Firestore에서 가져온 최종 결과
                 )
                 

--- a/FitMate/FitMate/Scene/Running/RunningCoop/View/RunningCoopViewController.swift
+++ b/FitMate/FitMate/Scene/Running/RunningCoop/View/RunningCoopViewController.swift
@@ -161,13 +161,15 @@ final class RunningCoopViewController: BaseViewController {
     }
     
     private func navigateToFinish(success: Bool, myDistance: Double) {
+        let avatarType = AvatarType(rawValue: self.myCharacter) ?? .kaepy
+        
         let finishVM = FinishViewModel(
             mode: .cooperation,
             sport: exerciseType,
             goal: goalDistance,
             goalUnit: "Km",
             myDistance: myDistance,
-            character: myCharacter,
+            avatarType: avatarType,
             success: success
         )
         

--- a/FitMate/FitMate/Scene/Shop/View/ShopViewController.swift
+++ b/FitMate/FitMate/Scene/Shop/View/ShopViewController.swift
@@ -151,7 +151,7 @@ class ShopViewController: BaseViewController, UICollectionViewDelegateFlowLayout
                 
                 // 해금된 아바타만 Firestore에 저장
                 if model.isUnlocked {
-                    FirestoreService.shared.saveSelectedAvatar(uid: self.uid, type: model.type, mateUid: self.mateUid)
+                    FirestoreService.shared.saveSelectedAvatar(uid: self.uid, type: model.type)
                 }
                 
                 self.rootView.avatarCollection.reloadData()
@@ -193,12 +193,17 @@ class ShopViewController: BaseViewController, UICollectionViewDelegateFlowLayout
                     var selected = model
                     selected.isUnlocked = true
                     
+                    // 전체 아바타 리스트에서 해당 모델 갱신
                     var updated = self.viewModel.allAvatarsRelay.value
                     if let index = updated.firstIndex(where: { $0.type == selected.type }) {
                         updated[index] = selected
                     }
                     self.viewModel.allAvatarsRelay.accept(updated)
                     
+                    // Firestore에 해금 정보만 저장 (대표 아바타 저장 )
+                    FirestoreService.shared.saveUnlockedAvatar(uid: self.uid, newType: selected.type)
+                    
+                    // UI 미리보기만 업데이트 (선택 아바타는 그대로 유지)
                     if let image = UIImage(named: selected.imageName),
                        let cgImage = image.cgImage {
                         let fixed = UIImage(cgImage: cgImage, scale: image.scale, orientation: .up)
@@ -206,15 +211,12 @@ class ShopViewController: BaseViewController, UICollectionViewDelegateFlowLayout
                         self.rootView.selectedAvatarImg.image = flipped
                     }
                     
-                    self.viewModel.selectedAvatarRelay.accept(selected)
+                    self.rootView.avatarNameStack.updateNickname(selected.avatarName)
                     
-                    // Firestore에 해금 정보 + 대표 아바타 저장
-                    FirestoreService.shared.saveUnlockedAvatar(uid: self.uid, newType: selected.type)
-                    FirestoreService.shared.saveSelectedAvatar(
-                        uid: self.uid, type: selected.type, mateUid: self.mateUid)
-                    
+                    // 아바타 목록 새로고침 (잠금 해제 반영)
                     self.viewModel.fetchAvatars(uid: self.uid)
                 }
+
                 popup.onCancel = {
                     print("구매 취소")
                 }
@@ -236,12 +238,10 @@ class ShopViewController: BaseViewController, UICollectionViewDelegateFlowLayout
             .withLatestFrom(selectedAvatarInfo) // 현재 선택된 아바타 모델
             .subscribe(onNext: { [weak self] selected in
                 guard let self else { return }
-
-                /// : Firestore + 전역 상태 갱신
+                /// Firestore + 전역 상태 갱신
                 AvatarManager.shared.updateAvatar(
                     uid: self.uid,
-                    avatarType: selected.type,
-                    mateUid: self.mateUid
+                    avatarType: selected.type
                 )
                 /// 선택된 아바타 기준 체인지 버튼 보이게 안보이게
                 self.viewModel.currentAvatarTypeRelay.accept(selected.type)


### PR DESCRIPTION
close #309 
<!-- close #No(이슈 넘버 등록하면 자동으로 이슈가 닫힙니다. 이슈를 닫고 싶지 않다면, 즉 해당 이슈의 작업이 아직 끝나지 않았다면 닫지 않습니다.) -->

## *⛳️ Work Description*

- 운동 화면 캐릭터 로직을 아바타 타입 기반으로 변경
- 메이트가 아바타 구매만 하면 내 메인에 반영되던 오류 개선
-  내 아바타와 메이트 아바타 로직 책임 분리
- goToGameScreen에서 mateUid 계산 조건 잘못돼 빈 문자열 전달되던 문제 수정

## *📸 Screenshot*

![Simulator Screen Recording - iPhone 16 Pro Max - 2025-07-02 at 13 12 50](https://github.com/user-attachments/assets/ec9b8401-b92f-4de2-95a3-47fe0e23a18e)


## *📢 To Reviewers*

<!-- 이 PR을 리뷰하는 사람들에게 할 말이 있다면 작성하시면 됩니다. -->

- 코드리뷰 부탁드립니다.

## *✅ Checklist*

<!-- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다. -->

- [x]  주석 및 프린트문 제거 확인.
- [x]  컨벤션 준수 확인.
