### PR TITLE
[Fix] #295 메이트가 있는 유저에게 메이트 초대를 하면 초대 실패 Alert 띄우도록 수정

### DIFF
--- a/FitMate/FitMate/Scene/CodeShare/ViewModel/MateCodeViewModel.swift
+++ b/FitMate/FitMate/Scene/CodeShare/ViewModel/MateCodeViewModel.swift
@@ -71,7 +71,8 @@ class MateCodeViewModel {
                     .flatMap { inviterData -> Single<(CustomAlertType?, Navigation?)> in
                         // 조회된 데이터에서 uid, nickname 추출
                         guard let inviterUid = inviterData["uid"] as? String,
-                              let inviterNickname = inviterData["nickname"] as? String else {
+                              let inviterNickname = inviterData["nickname"] as? String,
+                              let hasMate = inviterData["hasMate"] as? Bool else {
                             return .just((.requestFailed(message: "올바르지 않은 사용자 정보입니다"), nil))
                         }
                         
@@ -79,6 +80,10 @@ class MateCodeViewModel {
                         // 자신의 초대코드를 입력한 경우 → 에러 처리
                         if inviterUid == self.uid {
                             return .just((.requestFailed(message: "자신의 초대 코드는 입력할 수 없습니다."), nil))
+                        }
+                        
+                        if hasMate {
+                            return .just((.requestFailed(message: "이미 메이트와 연결된 사용자입니다."), nil))
                         }
 
                         // 해당 사용자의 문서에 초대 상태, 보낸 사람 UID 업데이트


### PR DESCRIPTION
close #295 
<!-- close #No(이슈 넘버 등록하면 자동으로 이슈가 닫힙니다. 이슈를 닫고 싶지 않다면, 즉 해당 이슈의 작업이 아직 끝나지 않았다면 닫지 않습니다.) -->

## *⛳️ Work Description*

<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

### 수정 전
- 메이트가 있는 유저에게 메이트 초대를 보내는게 가능함.

### 수정  후
- 메이트가 있는 유저에게 메이트 초대를 보내는 경우 `초대 요청 실패` Alert 를 띄움

## *📸 Screenshot*
![Simulator Screen Recording - iPhone 16 Pro - 2025-07-02 at 23 27 10](https://github.com/user-attachments/assets/09ad3b3a-681b-429f-aae5-ec0b7a25b9b4)

<!-- 구현한 부분의 시뮬레이터 스크린샷을 올려주시면 됩니다. -->
<!-- 기기대응을 위해 사이즈가 다른 기기별로 스크린샷을 올리기도 합니다. -->
<!-- 움직이는 동작일 경우, 시뮬레이터 영상을 녹화하고 gif로 저장하여 드래그 앤 드롭을 통해 업로드하면 됩니다. -->

## *📢 To Reviewers*

<!-- 이 PR을 리뷰하는 사람들에게 할 말이 있다면 작성하시면 됩니다. -->

- 코드리뷰 부탁드립니다.

## *✅ Checklist*

<!-- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다. -->

- [x]  주석 및 프린트문 제거 확인.
- [x]  컨벤션 준수 확인.
