### PR TITLE
[Fix] #331 목표치 범위 수정, 효과음 이슈들 해결

### DIFF
--- a/FitMate/FitMate/App/SceneDelegate.swift
+++ b/FitMate/FitMate/App/SceneDelegate.swift
@@ -17,11 +17,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                willConnectTo session: UISceneSession,
                options connectionOptions: UIScene.ConnectionOptions) {
         
-        SoundManage.shared.isSoundEnabled = UserDefaults.standard.object(forKey: "soundEnabled") as? Bool ?? true
-        
         guard let windowScene = (scene as? UIWindowScene) else { return }
         
         let window = UIWindow(windowScene: windowScene)
+        
+        SoundManage.shared.initializeSoundSetting()
         
         window.rootViewController = UINavigationController(rootViewController: SplashViewController())
         window.makeKeyAndVisible()

--- a/FitMate/FitMate/Common/Components/SoundManager.swift
+++ b/FitMate/FitMate/Common/Components/SoundManager.swift
@@ -11,10 +11,26 @@ class SoundManage {
     static let shared = SoundManage()
     private var audioPlayer: AVAudioPlayer?
     
-    var isSoundEnabled: Bool = true
+    var isSoundEnabled: Bool {
+        get {
+            UserDefaults.standard.object(forKey: "soundEnabled") as? Bool ?? true
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: "soundEnabled")
+            UserDefaults.standard.synchronize()
+        }
+    }
     
     private init() {}
     
+    func initializeSoundSetting() {
+        if let saved = UserDefaults.standard.object(forKey: "soundEnabled") as? Bool {
+            isSoundEnabled = saved
+        } else {
+            isSoundEnabled = true
+        }
+    }
+
     func coinSound() {
         guard isSoundEnabled else { return }
         guard let url = Bundle.main.url(forResource: "coin", withExtension: "wav") else { return }

--- a/FitMate/FitMate/Scene/Finish/View/FinishViewController.swift
+++ b/FitMate/FitMate/Scene/Finish/View/FinishViewController.swift
@@ -7,6 +7,7 @@ class FinishViewController: BaseViewController {
     
     private let finishView = FinishView()
     private let viewModel: FinishViewModel
+
     let uid: String
     let mateUid: String
     let matchCode: String
@@ -27,6 +28,12 @@ class FinishViewController: BaseViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        if viewModel.success {
+            SoundManage.shared.playSuccess()
+        } else {
+            SoundManage.shared.playFail()
+        }
         
         let reward = calculateReward(
             exerciseType: viewModel.sport,

--- a/FitMate/FitMate/Scene/GoalSelection/ViewModel/GoalSelectionViewModel.swift
+++ b/FitMate/FitMate/Scene/GoalSelection/ViewModel/GoalSelectionViewModel.swift
@@ -44,21 +44,21 @@ class GoalSelectionViewModel: ViewModelType {
             .map { title, mode in
                 switch (title, mode) {
                 case ("걷기", .cooperation):
-                    return Array(2...20).map { "\($0) km" }
+                    return Array(1...20).map { "\($0) km" }
                 case ("걷기", .battle):
                     return Array(1...10).map { "\($0) km" }
                 case ("달리기", .cooperation):
-                    return Array(2...40).map { "\($0) km" }
+                    return Array(1...40).map { "\($0) km" }
                 case ("달리기", .battle):
                     return Array(1...20).map { "\($0) km" }
                 case ("자전거", .cooperation):
-                    return Array(4...60).map { "\($0) km" }
+                    return Array(1...60).map { "\($0) km" }
                 case ("자전거", .battle):
-                    return Array(2...30).map { "\($0) km" }
+                    return Array(1...30).map { "\($0) km" }
                 case ("플랭크", _):
-                    return Array(2...10).map { "\($0) 분" }
+                    return Array(stride(from: 2, through: 20, by: 2)).map { "\($0) 분" }
                 case ("줄넘기", .cooperation):
-                    return Array(stride(from: 200, through: 2000, by: 100)).map { "\($0)회" }
+                    return Array(stride(from: 100, through: 2000, by: 100)).map { "\($0)회" }
                 case ("줄넘기", .battle):
                     return Array(stride(from: 100, through: 1500, by: 100)).map { "\($0)회" }
                     

--- a/FitMate/FitMate/Scene/JumpRope/JumpRopeBattle/View/JumpRopeBattleViewController.swift
+++ b/FitMate/FitMate/Scene/JumpRope/JumpRopeBattle/View/JumpRopeBattleViewController.swift
@@ -118,6 +118,11 @@ class JumpRopeBattleViewController: BaseViewController {
             .disposed(by: disposeBag)
         
         output.didFinish
+            .distinctUntilChanged({ prev, curr in
+              let prevSuccess = prev
+              let currSuccess = curr
+              return prevSuccess == currSuccess ? true : false
+            })
             .emit(onNext: { [weak self] success in
                 self?.navigateToFinish(success: success)
             })

--- a/FitMate/FitMate/Scene/JumpRope/JumpRopeCoop/View/JumpRopeCoopViewController.swift
+++ b/FitMate/FitMate/Scene/JumpRope/JumpRopeCoop/View/JumpRopeCoopViewController.swift
@@ -116,6 +116,11 @@ class JumpRopeCoopViewController: BaseViewController {
             .disposed(by: disposeBag)
         
         output.didFinish
+            .distinctUntilChanged({ prev, curr in
+              let prevSuccess = prev
+              let currSuccess = curr
+              return prevSuccess == currSuccess ? true : false
+            })
             .emit(onNext: { [weak self] success in
                 self?.navigateToFinish(success: success)
             })

--- a/FitMate/FitMate/Scene/Plank/PlankCoop/View/PlankCoopViewController.swift
+++ b/FitMate/FitMate/Scene/Plank/PlankCoop/View/PlankCoopViewController.swift
@@ -211,6 +211,11 @@ final class PlankCoopViewController: BaseViewController {
             .disposed(by: disposeBag)
         // 게임 종료시 결과화면 이동
         output.didFinish
+            .distinctUntilChanged({ prev, curr in
+              let prevSuccess = prev
+              let currSuccess = curr
+              return prevSuccess == currSuccess ? true : false
+            })
             .emit(with: self) { owner, success in
                 owner.navigateToFinish(success: success)
             }
@@ -257,7 +262,6 @@ final class PlankCoopViewController: BaseViewController {
             type: .mateQuit,
             onBack: { [weak self] in
                 guard let self else { return }
-                SoundManage.shared.playFail()
                 self.viewModel.finish(success: false)
                 self.navigateToFinish(success: false)
             }

--- a/FitMate/FitMate/Scene/Running/RunningBattle/View/RunningBattleViewController.swift
+++ b/FitMate/FitMate/Scene/Running/RunningBattle/View/RunningBattleViewController.swift
@@ -137,12 +137,12 @@ class RunningBattleViewController: BaseViewController {
             .disposed(by: disposeBag)
         
         output.didFinish
+            .distinctUntilChanged({ prev, curr in
+              let prevSuccess = prev.0
+              let currSuccess = curr.0
+              return prevSuccess == currSuccess ? true : false
+            })
             .emit(onNext: { [weak self] (success, myDistance) in
-                if success {
-                    SoundManage.shared.playSuccess()
-                } else {
-                    SoundManage.shared.playFail()
-                }
                 self?.navigateToFinish(success: success, myDistance: myDistance)
             })
             .disposed(by: disposeBag)

--- a/FitMate/FitMate/Scene/Running/RunningCoop/View/RunningCoopViewController.swift
+++ b/FitMate/FitMate/Scene/Running/RunningCoop/View/RunningCoopViewController.swift
@@ -137,12 +137,12 @@ final class RunningCoopViewController: BaseViewController {
             .disposed(by: disposeBag)
         
         output.didFinish
+            .distinctUntilChanged({ prev, curr in
+              let prevSuccess = prev.0
+              let currSuccess = curr.0
+              return prevSuccess == currSuccess ? true : false
+            })
             .emit(onNext: { [weak self] (success, myDistance) in
-                if success {
-                    SoundManage.shared.playSuccess()
-                } else {
-                    SoundManage.shared.playFail()
-                }
                 self?.navigateToFinish(success: success, myDistance: myDistance)
             })
             .disposed(by: disposeBag)


### PR DESCRIPTION
close #331

## *⛳️ Work Description*

- 효과음 토글이 off일 때 앱을 껐다 돌아오면 토글은off인 상태로 효과음이 들리는 이슈 해결
- 승리 효과음과 실패 효과음이 뷰가 호출 될 때마다 여러번 들리는 이슈 해결
- 목표치 범위 수정

## *📸 Screenshot*

- 스크린샷 필요 없습니당

## *📢 To Reviewers*

- 코드리뷰 부탁드립니다.

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거 확인.
- [ ]  컨벤션 준수 확인.
