### PR TITLE
[Fix] #341 운동 선택 화면 iPhone16 Pro Max 대응

### DIFF
--- a/FitMate/FitMate/Scene/SportsMode/View/SportsModeViewController.swift
+++ b/FitMate/FitMate/Scene/SportsMode/View/SportsModeViewController.swift
@@ -143,6 +143,15 @@ class SportsModeViewController: BaseViewController {
         return label
     }()
     
+    // 모드 버튼 스택뷰
+    private let buttonStack: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.spacing = 20
+        stackView.distribution = .fillEqually
+        return stackView
+    }()
+    
     // 협력 모드 선택 버튼
     private let cooperationModeButton: UIButton = {
         let button = UIButton(type: .system)
@@ -212,18 +221,23 @@ class SportsModeViewController: BaseViewController {
             backgroundView,
             titleLabel,
             middleContainer,
-            cooperationModeButton,
-            battleModeButton
+            buttonStack
+//            cooperationModeButton,
+//            battleModeButton
         ].forEach { view.addSubview($0) } // 모든 요소 메인 뷰에 추가
         
         middleContainer.addSubview(infoStackView)
+        
+        buttonStack.addArrangedSubview(cooperationModeButton)
+        buttonStack.addArrangedSubview(battleModeButton)
 
         let safeArea = view.safeAreaLayoutGuide
         // 오토레이아웃 설정
         backgroundView.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide).inset(24)
             $0.leading.trailing.equalToSuperview().inset(20)
-            $0.height.equalTo(307)
+//            $0.height.equalTo(307)
+            $0.bottom.equalTo(titleLabel.snp.top).inset(-20)
         }
         imageView.snp.makeConstraints {
             $0.centerX.equalToSuperview()
@@ -232,11 +246,12 @@ class SportsModeViewController: BaseViewController {
             $0.height.equalTo(272)
         }
         titleLabel.snp.makeConstraints {
-            $0.top.equalTo(backgroundView.snp.bottom).offset(24)
+            //$0.top.equalTo(backgroundView.snp.bottom).offset(24)
+            $0.bottom.equalTo(middleContainer.snp.top)
             $0.leading.trailing.equalToSuperview().inset(20)
         }
         middleContainer.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom)
+            //$0.top.equalTo(titleLabel.snp.bottom)
             $0.bottom.equalTo(cooperationModeButton.snp.top)
             $0.leading.trailing.equalToSuperview()
         }
@@ -244,7 +259,9 @@ class SportsModeViewController: BaseViewController {
         // infoStackView: middleContainer의 정중앙!
         infoStackView.snp.makeConstraints {
             $0.centerY.equalToSuperview()
+            $0.top.equalToSuperview().offset(20)
             $0.leading.trailing.equalToSuperview().inset(20)
+            $0.bottom.equalToSuperview().inset(20)
         }
 //        descriptionLabelTitle.snp.makeConstraints {
 //            $0.top.equalTo(titleLabel.snp.bottom).offset(25)
@@ -277,18 +294,26 @@ class SportsModeViewController: BaseViewController {
 //            $0.top.equalTo(caloriesLabelText.snp.bottom).offset(10)
 //            $0.leading.trailing.equalToSuperview().inset(20)
 //        }
-        cooperationModeButton.snp.makeConstraints {
+        
+        buttonStack.snp.makeConstraints {
+            //$0.top.equalTo(middleContainer.snp.bottom).offset(30)
             $0.bottom.equalTo(safeArea.snp.bottom).inset(36)
-            $0.leading.equalToSuperview().inset(20)
-            $0.width.equalTo(157.5)
+            $0.horizontalEdges.equalToSuperview().inset(20)
             $0.height.equalTo(60)
         }
-        battleModeButton.snp.makeConstraints {
-            $0.bottom.equalTo(safeArea.snp.bottom).inset(36)
-            $0.trailing.equalToSuperview().inset(20)
-            $0.width.equalTo(157.5)
-            $0.height.equalTo(60)
-        }
+        
+//        cooperationModeButton.snp.makeConstraints {
+//            $0.bottom.equalTo(safeArea.snp.bottom).inset(36)
+//            $0.leading.equalToSuperview().inset(20)
+//            $0.width.equalTo(157.5)
+//            $0.height.equalTo(60)
+//        }
+//        battleModeButton.snp.makeConstraints {
+//            $0.bottom.equalTo(safeArea.snp.bottom).inset(36)
+//            $0.trailing.equalToSuperview().inset(20)
+//            $0.width.equalTo(157.5)
+//            $0.height.equalTo(60)
+//        }
     }
     
     // 운동 아이템을 기반으로 각 UI에 데이터 바인딩


### PR DESCRIPTION
close #341 
<!-- close #No(이슈 넘버 등록하면 자동으로 이슈가 닫힙니다. 이슈를 닫고 싶지 않다면, 즉 해당 이슈의 작업이 아직 끝나지 않았다면 닫지 않습니다.) -->

## *⛳️ Work Description*

<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

### 운동 선택 화면 iPhone16 Pro Max 대응
- 레이아웃 제약조건이 iPhone13 mini 기준 고정 크기로 할당됨
- 큰 화면에서 여백이 너무 크게 발생
- 따라서 제약조건을 고정값에서 유동적으로 변할 수 있게 수정

## *📸 Screenshot*
수정 전|수정 후
---|---
<img width="531" alt="image" src="https://github.com/user-attachments/assets/ee01530a-29a8-4bf9-b4f1-f138fee2eafe" />|<img width="531" alt="image" src="https://github.com/user-attachments/assets/3e237b64-0666-47d5-b29f-cec2584bbe01" />


<!-- 구현한 부분의 시뮬레이터 스크린샷을 올려주시면 됩니다. -->
<!-- 기기대응을 위해 사이즈가 다른 기기별로 스크린샷을 올리기도 합니다. -->
<!-- 움직이는 동작일 경우, 시뮬레이터 영상을 녹화하고 gif로 저장하여 드래그 앤 드롭을 통해 업로드하면 됩니다. -->

## *📢 To Reviewers*

<!-- 이 PR을 리뷰하는 사람들에게 할 말이 있다면 작성하시면 됩니다. -->

- 코드리뷰 부탁드립니다.

## *✅ Checklist*

<!-- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다. -->

- [x]  주석 및 프린트문 제거 확인.
- [x]  컨벤션 준수 확인.
