### PR TITLE
[Refactor] #373 코드 정리

### DIFF
--- a/FitMate/FitMate/Scene/GoalSelection/View/GoalSelectionViewController.swift
+++ b/FitMate/FitMate/Scene/GoalSelection/View/GoalSelectionViewController.swift
@@ -20,7 +20,7 @@ class GoalSelectionViewController: BaseViewController, UIPickerViewDataSource, U
     private var pickerData: [String] = []
     
     // 선택된 운동 제목을 전달하는 Rx Relay
-    private let selectedTitleRelay = BehaviorRelay<String>(value: "")
+    private let selectedTitleRelay = BehaviorRelay<SportsModeViewController.ExerciseType>(value: .walking)
     
     // 선택된 운동 모드를 전달하는 Rx Relay
     private let selectedModeRelay = BehaviorRelay<SportsModeViewController.ExerciseMode>(value: .cooperation)
@@ -145,7 +145,7 @@ class GoalSelectionViewController: BaseViewController, UIPickerViewDataSource, U
                 FirestoreService.shared.createMatchDocument(
                     inviterUid: self.uid,
                     inviteeUid: self.mateUid,
-                    exerciseType: self.selectedTitleRelay.value,
+                    exerciseType: self.selectedTitleRelay.value.rawValue,
                     goalValue: self.selectedGoalValueRelay.value,
                     goalUnit: self.selectedGoalUnitRelay.value,
                     mode: self.selectedModeRelay.value.asString
@@ -164,7 +164,7 @@ class GoalSelectionViewController: BaseViewController, UIPickerViewDataSource, U
     
     // 외부에서 선택된 운동 제목을 업데이트할 때 호출
     func updateSelectedTitle(_ title: String) {
-        selectedTitleRelay.accept(title)
+        selectedTitleRelay.accept(SportsModeViewController.ExerciseType(rawValue: title) ?? .running)
     }
     
     // 외부에서 선택된 운동 모드를 업데이트할 때 호출

--- a/FitMate/FitMate/Scene/GoalSelection/ViewModel/GoalSelectionViewModel.swift
+++ b/FitMate/FitMate/Scene/GoalSelection/ViewModel/GoalSelectionViewModel.swift
@@ -6,7 +6,7 @@ class GoalSelectionViewModel: ViewModelType {
     
     // ViewModel의 Input 정의: 외부에서 주입되는 selectedTitle 스트림
     struct Input {
-        let selectedTitle: Observable<String>
+        let selectedTitle: Observable<SportsModeViewController.ExerciseType>
         let selectedMode: Observable<SportsModeViewController.ExerciseMode>
     }
     
@@ -15,8 +15,8 @@ class GoalSelectionViewModel: ViewModelType {
         let pickerItems: Driver<[String]>
     }
     
-    // 선택된 운동 제목을 저장하는 BehaviorRelay (초기값은 빈 문자열)
-    let selectedGoalTitleRelay = BehaviorRelay<String>(value: "")
+    // 선택된 운동 제목을 저장하는 BehaviorRelay
+    let selectedGoalTitleRelay = BehaviorRelay<SportsModeViewController.ExerciseType>(value: .walking)
     // 선택된 운동 모드를 저장
     private let selectedModeRelay = BehaviorRelay<SportsModeViewController.ExerciseMode>(value: .cooperation)
     
@@ -35,34 +35,31 @@ class GoalSelectionViewModel: ViewModelType {
         
         return Output(pickerItems: pickerDataDriver)
     }
-    
-    
+        
     // 선택된 운동 제목에 따라 피커에 표시할 데이터를 반환하는 Driver
     private var pickerDataDriver: Driver<[String]> {
         Observable
             .combineLatest(selectedGoalTitleRelay, selectedModeRelay)
             .map { title, mode in
                 switch (title, mode) {
-                case ("걷기", .cooperation):
+                case (.walking, .cooperation):
                     return Array(1...20).map { "\($0) km" }
-                case ("걷기", .battle):
+                case (.walking, .battle):
                     return Array(1...10).map { "\($0) km" }
-                case ("달리기", .cooperation):
+                case (.running, .cooperation):
                     return Array(1...40).map { "\($0) km" }
-                case ("달리기", .battle):
+                case (.running, .battle):
                     return Array(1...20).map { "\($0) km" }
-                case ("자전거", .cooperation):
+                case (.cycling, .cooperation):
                     return Array(1...60).map { "\($0) km" }
-                case ("자전거", .battle):
+                case (.cycling, .battle):
                     return Array(1...30).map { "\($0) km" }
-                case ("플랭크", _):
+                case (.plank, _):
                     return Array(stride(from: 2, through: 20, by: 2)).map { "\($0) 분" }
-                case ("줄넘기", .cooperation):
+                case (.jumpRope, .cooperation):
                     return Array(stride(from: 100, through: 2000, by: 100)).map { "\($0)회" }
-                case ("줄넘기", .battle):
+                case (.jumpRope, .battle):
                     return Array(stride(from: 100, through: 1500, by: 100)).map { "\($0)회" }
-                default:
-                    return []
                 }
             }
             .asDriver(onErrorJustReturn: [])

--- a/FitMate/FitMate/Scene/Running/RunningBattle/View/RunningBattleViewController.swift
+++ b/FitMate/FitMate/Scene/Running/RunningBattle/View/RunningBattleViewController.swift
@@ -14,7 +14,7 @@ class RunningBattleViewController: BaseViewController {
     private let quitRelay = PublishRelay<Void>()
     private let mateQuitRelay = PublishRelay<Void>()
     private let mateDistanceRelay = PublishRelay<Double>()
-    private let locationAuthStatusRelay = BehaviorRelay<CLAuthorizationStatus>(value: CLLocationManager.authorizationStatus())
+    private let locationAuthStatusRelay = BehaviorRelay<CLAuthorizationStatus>(value: CLLocationManager().authorizationStatus)
     
     private let exerciseType: String
     private let goalDistance: Int
@@ -58,11 +58,11 @@ class RunningBattleViewController: BaseViewController {
         rootView.updateMateCharacter(mateCharacter)
         
         // 화면 진입 시 권한 상태 확인
-        locationAuthStatusRelay.accept(CLLocationManager.authorizationStatus())
+        locationAuthStatusRelay.accept(CLLocationManager().authorizationStatus)
         
         // 앱 포그라운드 복귀 시 권한 상태 체크
         NotificationCenter.default.rx.notification(UIApplication.didBecomeActiveNotification)
-            .map { _ in CLLocationManager.authorizationStatus() }
+            .map { _ in CLLocationManager().authorizationStatus}
             .bind(to: locationAuthStatusRelay)
             .disposed(by: disposeBag)
         

--- a/FitMate/FitMate/Scene/Running/RunningCoop/View/RunningCoopViewController.swift
+++ b/FitMate/FitMate/Scene/Running/RunningCoop/View/RunningCoopViewController.swift
@@ -11,7 +11,7 @@ final class RunningCoopViewController: BaseViewController {
     private let startRelay = PublishRelay<Void>()
     private let mateDistanceRelay = BehaviorRelay<Double>(value: 0)
     private let goalselecionViewModel = GoalSelectionViewModel()
-    private let locationAuthStatusRelay = BehaviorRelay<CLAuthorizationStatus>(value: CLLocationManager.authorizationStatus())
+    private let locationAuthStatusRelay = BehaviorRelay<CLAuthorizationStatus>(value: CLLocationManager().authorizationStatus)
     
     private let exerciseType: String
     private let goalDistance: Int
@@ -65,11 +65,11 @@ final class RunningCoopViewController: BaseViewController {
         rootView.updateMateCharacter(runningCoopViewModel.mateCharacter)
         
         // 화면 진입 시 권한 상태 체크
-        locationAuthStatusRelay.accept(CLLocationManager.authorizationStatus())
+        locationAuthStatusRelay.accept(CLLocationManager().authorizationStatus)
         
         // 앱 포그라운드 복귀 시 권한 상태 체크
         NotificationCenter.default.rx.notification(UIApplication.didBecomeActiveNotification)
-            .map { _ in CLLocationManager.authorizationStatus() }
+            .map { _ in CLLocationManager().authorizationStatus }
             .bind(to: locationAuthStatusRelay)
             .disposed(by: disposeBag)
         

--- a/FitMate/FitMate/Scene/SportsMode/View/SportsModeViewController.swift
+++ b/FitMate/FitMate/Scene/SportsMode/View/SportsModeViewController.swift
@@ -23,6 +23,15 @@ class SportsModeViewController: BaseViewController {
         }
     }
     
+    enum ExerciseType: String {
+        case walking = "걷기"
+        case running = "달리기"
+        case cycling = "자전거"
+        case plank = "플랭크"
+        case jumpRope = "줄넘기"
+    }
+
+    
     // 모드 선택 이벤트를 전달하는 Relay (Rx 방식)
     private let modeSelectedRelay = PublishRelay<(String, ExerciseMode)>()
     

--- a/FitMate/FitMate/Scene/SportsSelection/View/SportsSelectionModel.swift
+++ b/FitMate/FitMate/Scene/SportsSelection/View/SportsSelectionModel.swift
@@ -110,7 +110,6 @@ class CarouselCell: UICollectionViewCell {
             $0.centerY.equalToSuperview()
             $0.width.equalTo(132)
             $0.height.equalTo(144)
-            $0.width.equalTo(172)
         }
         
         titleLabel.snp.makeConstraints {

--- a/FitMate/FitMate/Scene/TabBar/TabBarController.swift
+++ b/FitMate/FitMate/Scene/TabBar/TabBarController.swift
@@ -54,39 +54,39 @@ class TabBarController: UITabBarController {
     private func configureTabBar() {
         
         let historyVC = HistoryViewController(uid: self.uid)
-        let nav1 = UINavigationController(rootViewController: historyVC)
+        let historyNav = UINavigationController(rootViewController: historyVC)
         
-        nav1.tabBarItem = UITabBarItem(
+        historyNav.tabBarItem = UITabBarItem(
             title: "기록",
             image: UIImage(named: "history"),
             selectedImage: UIImage(named: "historyTapped")
         )
         
         let mainVC = MainViewController(uid: self.uid, mateUid: self.uid)
-        let nav2 = UINavigationController(rootViewController: mainVC)
-        nav2.tabBarItem = UITabBarItem(
+        let mainNav = UINavigationController(rootViewController: mainVC)
+        mainNav.tabBarItem = UITabBarItem(
             title: "홈",
             image: UIImage(named: "main"),
             selectedImage: UIImage(named: "mainTapped")
         )
         
         let shopVC = ShopViewController(uid: self.uid, mateUid: self.uid)
-        let nav3 = UINavigationController(rootViewController: shopVC)
-        nav3.tabBarItem = UITabBarItem(
+        let shopNav = UINavigationController(rootViewController: shopVC)
+        shopNav.tabBarItem = UITabBarItem(
             title: "상점",
             image: UIImage(named: "shop"),
             selectedImage: UIImage(named: "shopTapped")
         )
         
         let myPageVC = MypageViewController(uid: self.uid)
-        let nav4 = UINavigationController(rootViewController: myPageVC)
-        nav4.tabBarItem = UITabBarItem(
+        let myPageNav = UINavigationController(rootViewController: myPageVC)
+        myPageNav.tabBarItem = UITabBarItem(
             title: "마이페이지",
             image: UIImage(named: "mypage"),
             selectedImage: UIImage(named: "mypageTapped")
         )
         
-        viewControllers = [nav2, nav3, nav1, nav4]
+        viewControllers = [mainNav, shopNav, historyNav, myPageNav]
     }
     
     private func setUp() {


### PR DESCRIPTION
close #373

## *⛳️ Work Description*

- GoalSelectionViewModel 에서 걷기, 달리기 등 종목 enum으로 관리
- RunningBattleViewController 파일에서 CLLocationManager.authorizationSataus 부분이 iOS 14.0버전에서 deprecated 되는 것 수정
- SportsSelectionModel.swift 파일 중복 width 수정
- TabBarController 에서 VC 이름 바꾸기

## *📸 Screenshot*

- 스크린샷 필요 없음

## *📢 To Reviewers*

- 코드리뷰 부탁드립니다.

## *✅ Checklist*

- [ ]  주석 및 프린트문 제거 확인.
- [ ]  컨벤션 준수 확인.
