### PR TITLE
[Fix] /#394 switch 문에서 fatalError 제거 및 앱 크래시 방지

### DIFF
--- a/FitMate/FitMate/Scene/History/View/HistoryViewController.swift
+++ b/FitMate/FitMate/Scene/History/View/HistoryViewController.swift
@@ -135,9 +135,12 @@ extension HistoryViewController: UICollectionViewDataSource {
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PlankRecordCell.identifier, for: indexPath) as! PlankRecordCell
             cell.configure(with: record)
             return cell
-
         default:
-            fatalError("종목 없음")
+        #if DEBUG // DEBUG 환경에서만 경고를 출력
+            // assertionFailure는 콘솔에 오류 메시지를 출력하고 중단(breakpoint)함.
+            assertionFailure("정의되지 않은 운동 타입: \(record.type)")
+        #endif
+            return UICollectionViewCell()
         }
     }
 }


### PR DESCRIPTION
close #394 
<!-- close #No(이슈 넘버 등록하면 자동으로 이슈가 닫힙니다. 이슈를 닫고 싶지 않다면, 즉 해당 이슈의 작업이 아직 끝나지 않았다면 닫지 않습니다.) -->

## *⛳️ Work Description*
- switch 문에서 default 케이스에 fatalError문이 사용 중 
- 추후 enum에 새로운 case가 추가되면 앱기 크래시 발생 됨.
- 해당 부분을 제거하고 기본 cell을 리턴하여 앱 크래시 방지 함.
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- 변경 사항을 작성하세요.

## *📸 Screenshot*
- 스크린샷 대응 없음
<!-- 구현한 부분의 시뮬레이터 스크린샷을 올려주시면 됩니다. -->
<!-- 기기대응을 위해 사이즈가 다른 기기별로 스크린샷을 올리기도 합니다. -->
<!-- 움직이는 동작일 경우, 시뮬레이터 영상을 녹화하고 gif로 저장하여 드래그 앤 드롭을 통해 업로드하면 됩니다. -->

## *📢 To Reviewers*

<!-- 이 PR을 리뷰하는 사람들에게 할 말이 있다면 작성하시면 됩니다. -->

- 코드리뷰 부탁드립니다.

## *✅ Checklist*

<!-- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다. -->

- [x]  주석 및 프린트문 제거 확인.
- [x]  컨벤션 준수 확인.
