### PR TITLE
[Refactor] #389 FirestoreService 인코딩 적용하기

### DIFF
--- a/FitMate/FitMate/Common/Service/Firebase/Firestore/FirestoreService.swift
+++ b/FitMate/FitMate/Common/Service/Firebase/Firestore/FirestoreService.swift
@@ -122,49 +122,39 @@ final class FirestoreService {
                     if isDuplicate {
                         // 중복이면 다시 시도 (재귀)
                         tryGenerateAndSave()
-                    } else {
-                        let newRef = self.db.collection("matches").document(matchCode)
-                        let data: [String: Any] = [
-                            "exerciseType": exerciseType, // 운동 종목
-                            "goalValue": goalValue, // 목표 수치
-                            "goalUnit": goalUnit,
-                            "mode": mode, // 운동 모드
-                            "matchStatus": "waiting", // waiting or started
-                            "inviterUid": inviterUid, // 운동 생성자 uid
-                            "inviteeUid": inviteeUid, // 운동 초대 받는 uid (mate)
-                            "createAt": FieldValue.serverTimestamp(), // 만든 시간
-                            // "startedAt": FieldValue.serverTimestamp(),     // 실제 시작 시각 넣을 땐 따로 업데이트
-                            // "finishedAt": FieldValue.serverTimestamp(),    // 실제 종료 시각 넣을 땐 따로 업데이트
-                            "players": [
-                                inviterUid: [
-                                    // "avatar": "끼리꼬", // 아바타 구현 되면 넣어야됨
-                                    "isOnline": true,
-                                    // "isWinner": true, // (대결모드에만 사용) 실제 게임 종료 후 따로 업데이트
-                                    "progress": 0.0,
-                                    "status": "waiting"
-                                ],
-                                inviteeUid: [
-                                    // "avatar": "끼리꼬",
-                                    "isOnline": true,
-                                    // "isWinner": true,
-                                    "progress": 0.0,
-                                    "status": "waiting"
-                                ]
-                            ]
-                        ]
-                        
-                        // Match 컬렉션의 MatchCode 문서 생성
-                        // 데이터 생성
-                        newRef.setData(data) { error in
+                    }
+                    
+                    let newRef = self.db.collection("matches").document(matchCode)
+                    
+                    let doc = MatchDocument(
+                        id: nil,
+                        exerciseType: exerciseType,
+                        goalValue: goalValue,
+                        goalUnit: goalUnit,
+                        mode: mode,
+                        matchStatus: "waiting",
+                        inviterUid: inviterUid,
+                        inviteeUid: inviteeUid,
+                        players: [
+                            inviterUid: .init(isOnline: true, progress: 0.0, status: "waiting"),
+                            inviteeUid: .init(isOnline: true, progress: 0.0, status: "waiting")
+                        ],
+                        createAt: nil
+                    )
+                    
+                    do {
+                        try newRef.setData(from: doc) { error in
                             if let error = error {
-                                single(.failure(error))
                                 print("Match 데이터 생성 실패: \(error.localizedDescription)")
+                                single(.failure(error))
                             } else {
-                                // MatchCode 반환
-                                single(.success(newRef.documentID))
                                 print("Match 데이터 생성 완료: 매치코드: \(matchCode)")
+                                single(.success(newRef.documentID))   // matchCode 반환
                             }
                         }
+                    } catch {
+                        print("인코딩 실패: \(error)")
+                        single(.failure(error))
                     }
                 }
             }

--- a/FitMate/FitMate/Common/Service/Firebase/Firestore/FirestoreService.swift
+++ b/FitMate/FitMate/Common/Service/Firebase/Firestore/FirestoreService.swift
@@ -57,36 +57,44 @@ final class FirestoreService {
                     if isDuplicate {
                         // 중복이면 다시 시도 (재귀)
                         tryGenerateAndSave()
-                    } else {
-                        let newRef = self.db.collection("users").document(uid)
-                        let data: [String: Any] = [
-                            "uid": uid,
-                            "coin": 0, // 코인 // 2025년 06월 29일 추가
-                            "inviteCode": inviteCode,
-                            "hasMate" : false, // 메이트 매칭 여부
-                            "totalStats": [ // 총 기록
-                                "walkingKm": 0, // 걷기
-                                "runningKm": 0, // 달리기
-                                "cyclingKm": 0, // 자전거
-                                "plankRounds": 0, // 플랭크
-                                "jumpRopeCount": 0 // 줄넘기
-                                          ],
-                            "winCount": 0,
-                            "loseCount": 0,
-                            "createAt": FieldValue.serverTimestamp(), // 만든 시간
-                        ]
-                        
-                        // users 컬렉션의 uid 문서 생성
-                        // 데이터 생성
-                        newRef.setData(data) { error in
+                        return
+                    }
+                    
+                    let newRef = self.db.collection("users").document(uid)
+                    let user = UserDocument(
+                        id: nil, // 문서 번호 자동 매칭
+                        uid: uid,
+                        coin: 0,
+                        inviteCode: inviteCode,
+                        hasMate: false,
+                        totalStats: .init(
+                            walkingKm: 0,
+                            runningKm: 0,
+                            cyclingKm: 0,
+                            plankRounds: 0,
+                            jumpRopeCount: 0
+                        ),
+                        winCount: 0,
+                        loseCount: 0,
+                        createAt: nil // 서버가 채움
+                    )
+                    
+                    // users 컬렉션의 uid 문서 생성
+                    // 데이터 생성
+                    do {
+                        try newRef.setData(from: user) { error in
                             if let error = error {
-                                single(.failure(error))
                                 print("User 데이터 생성 실패: \(error.localizedDescription)")
+                                single(.failure(error))
                             } else {
-                                single(.success(()))
                                 print("User 데이터 생성 완료: \(uid), 초대코드: \(inviteCode)")
+                                single(.success(()))
                             }
                         }
+                    } catch {
+                        // 인코딩 실패 시 여기로 옴
+                        print("인코딩 실패: \(error)")
+                        single(.failure(error))
                     }
                 }
             }

--- a/FitMate/FitMate/Common/Service/Firebase/Model/MatchDocument.swift
+++ b/FitMate/FitMate/Common/Service/Firebase/Model/MatchDocument.swift
@@ -1,0 +1,33 @@
+//
+//  MatchDocument.swift
+//  FitMate
+//
+//  Created by NH on 8/12/25.
+//
+
+import FirebaseFirestore
+import FirebaseCore   // Timestamp
+
+struct PlayerState: Codable {
+    var isOnline: Bool
+    var isWinner: Bool? // 대결 종료 후에만 사용
+    var progress: Double
+    var status: String // "waiting", "ready", "playing"...
+    var avatar: String?
+}
+
+struct MatchDocument: Codable {
+    @DocumentID var id: String? // = matchCode
+    let exerciseType: String
+    let goalValue: Int
+    let goalUnit: String
+    let mode: String // 예: "battle", "coop"
+    var matchStatus: String // "waiting", "started"
+    let inviterUid: String
+    let inviteeUid: String
+    var players: [String: PlayerState] // key = uid
+
+    @ServerTimestamp var createAt: Timestamp?
+    @ServerTimestamp var startedAt: Timestamp?
+    @ServerTimestamp var finishedAt: Timestamp?
+}

--- a/FitMate/FitMate/Common/Service/Firebase/Model/UserDocument.swift
+++ b/FitMate/FitMate/Common/Service/Firebase/Model/UserDocument.swift
@@ -1,0 +1,30 @@
+//
+//  UserDocument.swift
+//  FitMate
+//
+//  Created by NH on 8/12/25.
+//
+
+import FirebaseFirestore
+import FirebaseCore   // Timestamp
+
+/// Firestore 사용자 문서 모델 정의
+struct UserDocument: Codable {
+    @DocumentID var id: String? // 자동으로 문서 번호 매칭
+    let uid: String
+    var coin: Int
+    let inviteCode: String
+    var hasMate: Bool
+    var totalStats: TotalStats
+    var winCount: Int
+    var loseCount: Int
+    @ServerTimestamp var createAt: Timestamp? // 서버 시간 자동으로 넣어줌
+}
+
+struct TotalStats: Codable {
+    var walkingKm: Double
+    var runningKm: Double
+    var cyclingKm: Double
+    var plankRounds: Int
+    var jumpRopeCount: Int
+}

--- a/FitMate/FitMate/Scene/JumpRope/JumpRopeBattle/View/JumpRopeBattleViewController.swift
+++ b/FitMate/FitMate/Scene/JumpRope/JumpRopeBattle/View/JumpRopeBattleViewController.swift
@@ -6,45 +6,35 @@ import FirebaseFirestore
 
 // JumpRope 대결 모드 컨트롤러 (전체 흐름 제어, ViewModel과 View 연결 담당)
 class JumpRopeBattleViewController: BaseViewController {
-    
+    // MARK: - Properties
     // 루트 뷰
     private let sportsView = JumpRopeBattleView()
+    
     // 뷰모델 선언
     private var viewModel: JumpRopeBattleViewModel
+    
     // 시작 트리거용(버튼, viewDidLoad 등에서 신호 보낼 때 사용)
     private let startRelay = PublishRelay<Void>()
+    
     // 메이트 점프 횟수 수신용(상대방이 firebase에서 온 값으로 갱신할 때 쓸 수도 있음)
     private let mateCountRelay = PublishRelay<Double>()
     private let quitRelay = PublishRelay<Void>()
     private let mateQuitRelay = PublishRelay<Void>()
-    private let myCharacter: String
-    private let mateCharacter: String
-    private let matchCode: String
-    private let mateUid: String
-    private let myUid: String
     
-    // matchCode: String, myUid: String, mateUid: String,  myCharacter: String, mateCharacter: String -> ,matchInfo: MatchInfo으로 변경
-    init(goalCount: Int, matchCode: String, myUid: String, mateUid: String,  myCharacter: String, mateCharacter: String /*,matchInfo: MatchInfo*/) {
-        self.matchCode = matchCode
-        self.myUid = myUid
-        self.mateUid = mateUid
-        self.myCharacter = myCharacter
-        self.mateCharacter = mateCharacter
-        //        위에 5줄 하단 5줄 코드로 변경
-        //        matchCode = matchInfo.matchCode
-        //        myUid = matchInfo.myUid
-        //        mateUid = matchInfo.mateUid
-        //        myCharacter = matchInfo.myCharacter
-        //        mateCharacter = matchInfo.mateCharacter
-        
+    // 전달받은 운동 정보
+    private let matchInfo: MatchInfo
+    
+    // MARK: - Initializer
+    init(goalCount: Int, matchInfo: MatchInfo) {
+        self.matchInfo = matchInfo
         
         self.viewModel = JumpRopeBattleViewModel(
             goalCount: goalCount,
-            myCharacter: myCharacter,
-            mateCharacter: mateCharacter,
-            matchCode: matchCode,
-            myUID: myUid,
-            mateUID:mateUid
+            myCharacter: matchInfo.myCharacter,
+            mateCharacter: matchInfo.mateCharacter,
+            matchCode: matchInfo.matchCode,
+            myUID: matchInfo.myUid,
+            mateUID: matchInfo.mateUid
         )
         super.init(nibName: nil, bundle: nil)
     }
@@ -53,7 +43,7 @@ class JumpRopeBattleViewController: BaseViewController {
         fatalError("not implemented")
     }
     
-    
+    // MARK: - Lifecycle
     // loadView에서 커스텀 뷰 할당
     override func loadView() {
         self.view = sportsView
@@ -65,8 +55,8 @@ class JumpRopeBattleViewController: BaseViewController {
         UIApplication.shared.isIdleTimerDisabled = true
         sportsView.updateGoal("줄넘기 \(viewModel.goalCount)개")
         //(파이널베이스 내의 만약 캐릭터 이미지 바인딩 시 이곳에서)
-        sportsView.updateMyCharacter(myCharacter)
-        sportsView.updateMateCharacter(mateCharacter)
+        sportsView.updateMyCharacter(matchInfo.myCharacter)
+        sportsView.updateMateCharacter(matchInfo.mateCharacter)
         
         startRelay.accept(())
         
@@ -92,11 +82,13 @@ class JumpRopeBattleViewController: BaseViewController {
         UIApplication.shared.isIdleTimerDisabled = false
     }
     
+    // MARK: - DeInitializer
     // 혹시라도 강제 종료 시점이 있을 수 있으니
     deinit {
         UIApplication.shared.isIdleTimerDisabled = false
     }
     
+    // MARK: - Binding
     // ViewModel과 UI 바인딩
     override func bindViewModel() {
         let input = JumpRopeBattleViewModel.Input(
@@ -155,7 +147,7 @@ class JumpRopeBattleViewController: BaseViewController {
     
     // 피니쉬화면으로 이동
     private func navigateToFinish(success: Bool) {
-        let avatarType = AvatarType(rawValue: myCharacter) ?? .kaepy
+        let avatarType = AvatarType(rawValue: matchInfo.myCharacter) ?? .kaepy
         
         let finishVM = FinishViewModel(
             mode: .battle,
@@ -168,48 +160,14 @@ class JumpRopeBattleViewController: BaseViewController {
         )
         
         let vc = FinishViewController(
-            uid: myUid,
-            mateUid: mateUid,
-            matchCode: matchCode,
+            uid: matchInfo.myUid,
+            mateUid: matchInfo.mateUid,
+            matchCode: matchInfo.matchCode,
             viewModel: finishVM
         )
         
         vc.modalPresentationStyle = .fullScreen
         present(vc, animated: true)
-    }
-    
-    private func navigateToFinish() {
-        Firestore.firestore().collection("matches").document(matchCode)
-            .getDocument { [weak self] snapshot, error in
-                guard let self = self else { return }
-                guard let data = snapshot?.data(),
-                      let players = data["players"] as? [String: Any],
-                      let myData = players[self.myUid] as? [String: Any],
-                      let isWinner = myData["isWinner"] as? Bool else {
-                    return
-                }
-                
-                let avatarType = AvatarType(rawValue: self.myCharacter) ?? .kaepy
-                
-                let finishVM = FinishViewModel(
-                    mode: .battle,
-                    sport: "줄넘기",
-                    goal: self.viewModel.goalCount,
-                    goalUnit: "개",
-                    myDistance: Double(self.viewModel.myCount),
-                    avatarType: avatarType,
-                    success: isWinner  // Firestore에서 가져온 최종 결과
-                )
-                
-                let vc = FinishViewController(
-                    uid: self.myUid,
-                    mateUid: self.mateUid,
-                    matchCode: self.matchCode,
-                    viewModel: finishVM
-                )
-                vc.modalPresentationStyle = .fullScreen
-                self.present(vc, animated: true)
-            }
     }
     
     func receiveMateQuit()    {
@@ -219,9 +177,8 @@ class JumpRopeBattleViewController: BaseViewController {
             type: .mateQuit,
             onBack: { [weak self] in
                 // 피니쉬화면으로 이동 등
-                
                 self?.viewModel.finish(success: true) // 위치 정지 및 기록 저장
-                self?.navigateToFinish()
+                self?.navigateToFinish(success: true)
             }
         )
     }

--- a/FitMate/FitMate/Scene/JumpRope/JumpRopeCoop/View/JumpRopeCoopViewController.swift
+++ b/FitMate/FitMate/Scene/JumpRope/JumpRopeCoop/View/JumpRopeCoopViewController.swift
@@ -5,51 +5,44 @@ import RxCocoa
 
 // JumpRope 협동 모드 컨트롤러 (전체 흐름 제어, ViewModel과 View 연결 담당)
 class JumpRopeCoopViewController: BaseViewController {
-    
+    // MARK: - Properties
     // 루트 뷰
     private let sportsView = JumpRopeCoopView()
+    
     // 뷰모델 선언
     private var viewModel: JumpRopeCoopViewModel
+    
     // 시작 트리거용(버튼, viewDidLoad 등에서 신호 보낼 때 사용)
     private let startRelay = PublishRelay<Void>()
+    
     // 메이트 점프 횟수 수신용(상대방이 firebase에서 온 값으로 갱신할 때 쓸 수도 있음)
     private let mateCountRelay = PublishRelay<Int>()
     private let quitRelay = PublishRelay<Void>()
     private let mateQuitRelay = PublishRelay<Void>()
-    private let myCharacter: String
-    private let mateCharacter: String
-    private let matchCode: String
-    private let mateUid: String
-    private let myUid: String
     
-    // matchCode: String, myUid: String, mateUid: String,  myCharacter: String, mateCharacter: String -> ,matchInfo: MatchInfo으로 변경
-    init(goalCount: Int, matchCode: String, myUid: String, mateUid: String,  myCharacter: String, mateCharacter: String /*,matchInfo: MatchInfo*/) {
-        self.matchCode = matchCode
-        self.myUid = myUid
-        self.mateUid = mateUid
-        self.myCharacter = myCharacter
-        self.mateCharacter = mateCharacter
-        //        위에 5줄 하단 5줄 코드로 변경
-        //        matchCode = matchInfo.matchCode
-        //        myUid = matchInfo.myUid
-        //        mateUid = matchInfo.mateUid
-        //        myCharacter = matchInfo.myCharacter
-        //        mateCharacter = matchInfo.mateCharacter
+    // 전달받은 운동 정보
+    private let matchInfo: MatchInfo
+    
+    // MARK: - Initializer
+    init(goalCount: Int, matchInfo: MatchInfo) {
+        self.matchInfo = matchInfo
         
         self.viewModel = JumpRopeCoopViewModel(
             goalCount: goalCount,
-            myCharacter: myCharacter,
-            mateCharacter: mateCharacter,
-            matchCode: matchCode,
-            myUID: myUid,
-            mateUID: mateUid
+            myCharacter: matchInfo.myCharacter,
+            mateCharacter: matchInfo.mateCharacter,
+            matchCode: matchInfo.matchCode,
+            myUID: matchInfo.myUid,
+            mateUID: matchInfo.mateUid
         )
         super.init(nibName: nil, bundle: nil)
     }
     
-    required init?(coder: NSCoder) { fatalError("not implemented") }
+    required init?(coder: NSCoder) {
+        fatalError("not implemented")
+    }
     
-    
+    // MARK: - Lifecycle
     // loadView에서 커스텀 뷰 할당
     override func loadView() {
         self.view = sportsView
@@ -77,17 +70,20 @@ class JumpRopeCoopViewController: BaseViewController {
             }
             .disposed(by: disposeBag)
     }
+    
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         // 꺼짐 방지 해제
         UIApplication.shared.isIdleTimerDisabled = false
     }
     
+    // MARK: - DeInitializer
     // 혹시라도 강제 종료 시점이 있을 수 있으니
     deinit {
         UIApplication.shared.isIdleTimerDisabled = false
     }
     
+    // MARK: - Binding
     // ViewModel과 UI 바인딩
     override func bindViewModel() {
         let input = JumpRopeCoopViewModel.Input(
@@ -138,7 +134,7 @@ class JumpRopeCoopViewController: BaseViewController {
     }
     
     private func navigateToFinish(success: Bool) {
-        let avatarType = AvatarType(rawValue: self.myCharacter) ?? .kaepy
+        let avatarType = AvatarType(rawValue: self.matchInfo.myCharacter) ?? .kaepy
         
         let finishVM = FinishViewModel(
             mode: .cooperation,
@@ -149,9 +145,9 @@ class JumpRopeCoopViewController: BaseViewController {
             avatarType: avatarType,
             success: success
         )
-        let vc = FinishViewController(uid: myUid,
-                                      mateUid: mateUid,
-                                      matchCode: matchCode,
+        let vc = FinishViewController(uid: matchInfo.myUid,
+                                      mateUid: matchInfo.mateUid,
+                                      matchCode: matchInfo.matchCode,
                                       viewModel: finishVM)
         vc.modalPresentationStyle = .fullScreen
         present(vc, animated: true)

--- a/FitMate/FitMate/Scene/Loading/View/LoadingViewController.swift
+++ b/FitMate/FitMate/Scene/Loading/View/LoadingViewController.swift
@@ -157,26 +157,27 @@ class LoadingViewController: BaseViewController {
                 
                 let pushVC: UIViewController?
                 
+                // 중복되는 인자를 하나로 묶어서 간소화
+                let matchInfo = MatchInfo(
+                    matchCode: matchCode,
+                    myUid: myUid,
+                    mateUid: mateUid,
+                    myCharacter: myCharacter,
+                    mateCharacter: mateCharacter
+                )
+                
                 if mode == "battle" {
                     switch exerciseType {
                     case "걷기", "달리기", "자전거":
                         pushVC = RunningBattleViewController(
                             exerciseType: exerciseType,
                             goalDistance: goalValue,
-                            matchCode: matchCode,
-                            myUid: myUid,
-                            mateUid: mateUid,
-                            myCharacter: myCharacter,
-                            mateCharacter: mateCharacter
+                            matchInfo: matchInfo
                         )
                     case "줄넘기":
                         pushVC = JumpRopeBattleViewController(
                             goalCount: goalValue,
-                            matchCode: matchCode,
-                            myUid: myUid,
-                            mateUid: mateUid,
-                            myCharacter: myCharacter,
-                            mateCharacter: mateCharacter
+                            matchInfo: matchInfo
                         )
                     default: return
                     }
@@ -186,30 +187,18 @@ class LoadingViewController: BaseViewController {
                         pushVC = RunningCoopViewController(
                             exerciseType: exerciseType,
                             goalDistance: goalValue,
-                            matchCode: matchCode,
-                            myUid: myUid,
-                            mateUid: mateUid,
-                            myCharacter: myCharacter,
-                            mateCharacter: mateCharacter
+                            matchInfo: matchInfo
                         )
                     case "플랭크":
                         pushVC = PlankCoopViewController(
                             goalMinutes: goalValue,
-                            matchCode: matchCode,
-                            myUID: myUid,
-                            mateUID: mateUid,
                             isInviter: isInviter,
-                            myCharacter: myCharacter,
-                            mateCharacter: mateCharacter
+                            matchInfo: matchInfo
                         )
                     case "줄넘기":
                         pushVC = JumpRopeCoopViewController(
                             goalCount: goalValue,
-                            matchCode: matchCode,
-                            myUid: myUid,
-                            mateUid: mateUid,
-                            myCharacter: myCharacter,
-                            mateCharacter: mateCharacter
+                            matchInfo: matchInfo
                         )
                     default: return
                     }

--- a/FitMate/FitMate/Scene/Plank/PlankCoop/View/PlankCoopViewController.swift
+++ b/FitMate/FitMate/Scene/Plank/PlankCoop/View/PlankCoopViewController.swift
@@ -4,7 +4,7 @@ import RxCocoa
 
 // 플랭크 협동모드(코드베이스) 뷰컨트롤러
 final class PlankCoopViewController: BaseViewController {
-    
+    // MARK: - Properties
     private let sportsView = PlankCoopView()
     private let viewModel: PlankCoopViewModel
     
@@ -18,48 +18,25 @@ final class PlankCoopViewController: BaseViewController {
     private let mateQuitRelay = PublishRelay<Void>()   // 상대 그만두기
     
     // 유저/매치 정보
-    private let myCharacter: String      // 내 아바타
-    private let mateCharacter: String    // 상대 아바타
-    private let matchCode: String        // 경기 코드
-    private let myUID: String            // 내 UID
-    private let mateUID: String          // 상대 UID
     private let isInviter: Bool          // 내가 초대자인지 여부
+    private let matchInfo: MatchInfo
     
-    // matchCode: String, myUid: String, mateUid: String,  myCharacter: String, mateCharacter: String -> ,matchInfo: MatchInfo으로 변경
-    // myUID,mateUID 에러 뜰 시 이름 myUid, mateUid로 변경해줘야함
+    // MARK: - Initializer
     // 생성자(매치 기본정보 및 내/상대 정보 주입)
-    init(
-        goalMinutes: Int,
-        matchCode: String,
-        myUID: String,
-        mateUID: String,
-        isInviter: Bool,
-        myCharacter: String,
-        mateCharacter: String
-        /*,matchInfo: MatchInfo*/
-    ) {
+    // TODO: - isInviter 변수도 struct로 처리 해야될까?
+    init(goalMinutes: Int, isInviter: Bool, matchInfo: MatchInfo) {
         self.isInviter = isInviter
-        self.matchCode = matchCode
-        self.myUID = myUID
-        self.mateUID = mateUID
-        self.myCharacter = myCharacter
-        self.mateCharacter = mateCharacter
-        //        위에 5줄 하단 5줄 코드로 변경
-        //        matchCode = matchInfo.matchCode
-        //        myUid = matchInfo.myUid
-        //        mateUid = matchInfo.mateUid
-        //        myCharacter = matchInfo.myCharacter
-        //        mateCharacter = matchInfo.mateCharacter
+        self.matchInfo = matchInfo
         
         // 뷰모델 생성
         self.viewModel = PlankCoopViewModel(
             goalMinutes: goalMinutes,
-            matchCode: matchCode,
-            myUID: myUID,
-            mateUID: mateUID,
+            matchCode: matchInfo.matchCode,
+            myUID: matchInfo.myUid,
+            mateUID: matchInfo.mateUid,
             isInviter: isInviter,
-            myCharacter: myCharacter,
-            mateCharacter: mateCharacter
+            myCharacter: matchInfo.myCharacter,
+            mateCharacter: matchInfo.mateCharacter
         )
         super.init(nibName: nil, bundle: nil)
     }
@@ -68,6 +45,7 @@ final class PlankCoopViewController: BaseViewController {
         fatalError("not implemented")
     }
     
+    // MARK: - Lifecycle
     // 메인 뷰 할당
     override func loadView() { self.view = sportsView }
     
@@ -79,8 +57,8 @@ final class PlankCoopViewController: BaseViewController {
         
         // 목표/아바타 UI 업데이트
         sportsView.updateGoal("플랭크 \(viewModel.goalMinutes)분")
-        sportsView.updateMyCharacter(myCharacter)
-        sportsView.updateMateCharacter(mateCharacter)
+        sportsView.updateMyCharacter(matchInfo.myCharacter)
+        sportsView.updateMateCharacter(matchInfo.mateCharacter)
         
         // 주요 Rx 바인딩/Firestore 실시간 리스너 연결
         bind()
@@ -111,11 +89,13 @@ final class PlankCoopViewController: BaseViewController {
         UIApplication.shared.isIdleTimerDisabled = false
     }
     
+    // MARK: - DeInitializer
     // 만약 컨트롤러가 deinit될 때도 안전하게 해제
     deinit {
         UIApplication.shared.isIdleTimerDisabled = false
     }
     
+    // MARK: - Binding
     // ViewModel과 Rx 바인딩 세팅
     private func bind() {
         // Input - 버튼 등에서 발생한 이벤트를 ViewModel로 전달
@@ -238,7 +218,7 @@ final class PlankCoopViewController: BaseViewController {
     // 결과화면 이동(성공/실패)
     private func navigateToFinish(success: Bool) {
         // 내 아바타 타입 변환
-        let avatarType = AvatarType(rawValue: self.myCharacter) ?? .kaepy
+        let avatarType = AvatarType(rawValue: self.matchInfo.myCharacter) ?? .kaepy
         // 결과 화면용 뷰모델 생성
         let finishVM = FinishViewModel(
             mode: .cooperation,
@@ -251,9 +231,9 @@ final class PlankCoopViewController: BaseViewController {
         )
         // 결과 화면 푸시
         let vc = FinishViewController(
-            uid: myUID,
-            mateUid: mateUID,
-            matchCode: matchCode,
+            uid: matchInfo.myUid,
+            mateUid: matchInfo.mateUid,
+            matchCode: matchInfo.matchCode,
             viewModel: finishVM
         )
         vc.modalPresentationStyle = .fullScreen
@@ -261,8 +241,13 @@ final class PlankCoopViewController: BaseViewController {
     }
     
     // Rx 트리거 수동 호출 (상대방 액션 수신용)
-    func receiveMatePaused()  { matePauseRelay.accept(()) }
-    func receiveMateResumed() { mateResumeRelay.accept(()) }
+    func receiveMatePaused()  {
+        matePauseRelay.accept(())
+    }
+    
+    func receiveMateResumed() {
+        mateResumeRelay.accept(())
+    }
     
     // 상대가 그만둔 경우(=퇴장) → 알럿/효과음 → 결과화면 이동
     func receiveMateQuit() {

--- a/FitMate/FitMate/Scene/Running/RunningBattle/View/RunningBattleViewController.swift
+++ b/FitMate/FitMate/Scene/Running/RunningBattle/View/RunningBattleViewController.swift
@@ -6,7 +6,7 @@ import CoreLocation
 import FirebaseFirestore
 
 class RunningBattleViewController: BaseViewController {
-    
+    // MARK: - Properties
     private let rootView = RunningBattleView()
     private let viewModel: RunningBattleViewModel
     
@@ -16,36 +16,23 @@ class RunningBattleViewController: BaseViewController {
     private let mateDistanceRelay = PublishRelay<Double>()
     private let locationAuthStatusRelay = BehaviorRelay<CLAuthorizationStatus>(value: CLLocationManager().authorizationStatus)
     
+    // 전달받은 운동 정보
     private let exerciseType: String
     private let goalDistance: Int
-    private let matchCode: String
-    private let mateUid: String
-    private let myUid: String
-    private let myCharacter: String
-    private let mateCharacter: String
+    private let matchInfo: MatchInfo
     
-    // matchCode: String, myUid: String, mateUid: String,  myCharacter: String, mateCharacter: String -> ,matchInfo: MatchInfo으로 변경
-    init(exerciseType: String, goalDistance: Int, matchCode: String, myUid: String, mateUid: String, myCharacter: String, mateCharacter: String /*,matchInfo: MatchInfo*/) {
+    // MARK: - Initializer
+    init(exerciseType: String, goalDistance: Int, matchInfo: MatchInfo) {
         self.exerciseType = exerciseType
         self.goalDistance = goalDistance
-        self.matchCode = matchCode
-        self.myUid = myUid
-        self.mateUid = mateUid
-        self.myCharacter = myCharacter
-        self.mateCharacter = mateCharacter
-        //        위에 5줄 하단 5줄 코드로 변경
-        //        matchCode = matchInfo.matchCode
-        //        myUid = matchInfo.myUid
-        //        mateUid = matchInfo.mateUid
-        //        myCharacter = matchInfo.myCharacter
-        //        mateCharacter = matchInfo.mateCharacter
+        self.matchInfo = matchInfo
         
         self.viewModel = RunningBattleViewModel(
             goalDistance: goalDistance,
-            myCharacter: myCharacter,
-            mateCharacter: mateCharacter,
-            matchCode: matchCode,
-            myUid: myUid
+            myCharacter: matchInfo.myCharacter,
+            mateCharacter: matchInfo.mateCharacter,
+            matchCode: matchInfo.matchCode,
+            myUid: matchInfo.myUid
         )
         super.init(nibName: nil, bundle: nil)
     }
@@ -54,6 +41,7 @@ class RunningBattleViewController: BaseViewController {
         fatalError("not implemented")
     }
     
+    // MARK: - Lifecycle
     override func loadView() {
         self.view = rootView
     }
@@ -62,8 +50,8 @@ class RunningBattleViewController: BaseViewController {
         super.viewDidLoad()
         
         rootView.updateGoal("\(exerciseType) \(viewModel.goalDistance)Km")
-        rootView.updateMyCharacter(myCharacter)
-        rootView.updateMateCharacter(mateCharacter)
+        rootView.updateMyCharacter(matchInfo.myCharacter)
+        rootView.updateMateCharacter(matchInfo.mateCharacter)
         
         // 화면 진입 시 권한 상태 확인
         locationAuthStatusRelay.accept(CLLocationManager().authorizationStatus)
@@ -75,11 +63,11 @@ class RunningBattleViewController: BaseViewController {
             .disposed(by: disposeBag)
         
         FirestoreService.shared
-            .observeMateProgress(matchCode: matchCode, mateUid: mateUid)
+            .observeMateProgress(matchCode: matchInfo.matchCode, mateUid: matchInfo.mateUid)
             .bind(to: mateDistanceRelay)
             .disposed(by: disposeBag)
         
-        FirestoreService.shared.listenToMatchStatus(matchCode: matchCode)
+        FirestoreService.shared.listenToMatchStatus(matchCode: matchInfo.matchCode)
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] data in
                 guard let self = self else { return }
@@ -106,6 +94,7 @@ class RunningBattleViewController: BaseViewController {
             .disposed(by: disposeBag)
     }
     
+    // MARK: - Binding
     override func bindViewModel() {
         super.bindViewModel()
         
@@ -169,7 +158,7 @@ class RunningBattleViewController: BaseViewController {
     
     // 운동 종료 후 결과 화면 이동
     private func navigateToFinish(success: Bool, myDistance: Double) {
-        let avatarType = AvatarType(rawValue: self.myCharacter) ?? .kaepy
+        let avatarType = AvatarType(rawValue: self.matchInfo.myCharacter) ?? .kaepy
         
         let finishVM = FinishViewModel(
             mode: .battle,
@@ -181,9 +170,9 @@ class RunningBattleViewController: BaseViewController {
             success: success
         )
         let vc = FinishViewController(
-            uid: myUid,
-            mateUid: mateUid,
-            matchCode: matchCode,
+            uid: matchInfo.myUid,
+            mateUid: matchInfo.mateUid,
+            matchCode: matchInfo.matchCode,
             viewModel: finishVM
         )
         vc.modalPresentationStyle = .fullScreen
@@ -210,10 +199,10 @@ class RunningBattleViewController: BaseViewController {
                 guard let self = self else { return }
                 // 여기서 matchStatus를 "finished" 등으로 변경
                 FirestoreService.shared
-                    .updateMatchStatus(matchCode: self.matchCode, status: "finished")
+                    .updateMatchStatus(matchCode: self.matchInfo.matchCode, status: "finished")
                     .subscribe(onCompleted: {
                         // 탭바 진입
-                        let tabBarVC = TabBarController(uid: self.myUid)
+                        let tabBarVC = TabBarController(uid: self.matchInfo.myUid)
                         tabBarVC.modalPresentationStyle = .fullScreen
                         if let window = UIApplication.shared.connectedScenes
                             .compactMap({ ($0 as? UIWindowScene)?.keyWindow })
@@ -247,11 +236,11 @@ class RunningBattleViewController: BaseViewController {
         alert.addAction(UIAlertAction(title: "메인화면으로 이동", style: .cancel, handler: { [weak self] _ in
             guard let self = self else { return }
             FirestoreService.shared
-                .updateMatchStatus(matchCode: self.matchCode, status: "cancelLocation")
+                .updateMatchStatus(matchCode: self.matchInfo.matchCode, status: "cancelLocation")
                 .subscribe(
                     onCompleted: {
                         print("matchStatus: cancelLocation 저장 완료")
-                        let tabBarVC = TabBarController(uid: self.myUid)
+                        let tabBarVC = TabBarController(uid: self.matchInfo.myUid)
                         tabBarVC.modalPresentationStyle = .fullScreen
                         if let window = UIApplication.shared.connectedScenes
                             .compactMap({ ($0 as? UIWindowScene)?.keyWindow })

--- a/FitMate/FitMate/Scene/Running/RunningCoop/View/RunningCoopViewController.swift
+++ b/FitMate/FitMate/Scene/Running/RunningCoop/View/RunningCoopViewController.swift
@@ -6,6 +6,7 @@ import RxCocoa
 import CoreLocation
 
 final class RunningCoopViewController: BaseViewController {
+    // MARK: - Properties
     private let rootView = RunningCoopView()
     private let runningCoopViewModel: RunningCoopViewModel
     private let startRelay = PublishRelay<Void>()
@@ -13,39 +14,27 @@ final class RunningCoopViewController: BaseViewController {
     private let goalselecionViewModel = GoalSelectionViewModel()
     private let locationAuthStatusRelay = BehaviorRelay<CLAuthorizationStatus>(value: CLLocationManager().authorizationStatus)
     
+    // 전달받은 운동 정보
     private let exerciseType: String
     private let goalDistance: Int
-    private let matchCode: String
-    private let mateUid: String
-    private let myUid: String
-    private let myCharacter: String
-    private let mateCharacter: String
+    private let matchInfo: MatchInfo
+    
     private let quitRelay = PublishRelay<Void>()
     private let mateQuitRelay = PublishRelay<Void>()
     
-    // matchCode: String, myUid: String, mateUid: String,  myCharacter: String, mateCharacter: String -> ,matchInfo: MatchInfo으로 변경
-    init(exerciseType: String, goalDistance: Int, matchCode: String, myUid: String, mateUid: String, myCharacter: String, mateCharacter: String /*,matchInfo: MatchInfo*/) {
+    // MARK: - Initializer
+    init(exerciseType: String, goalDistance: Int, matchInfo: MatchInfo) {
         self.exerciseType = exerciseType
         self.goalDistance = goalDistance
-        self.matchCode = matchCode
-        self.myUid = myUid
-        self.mateUid = mateUid
-        self.myCharacter = myCharacter
-        self.mateCharacter = mateCharacter
-        //        위에 5줄 하단 5줄 코드로 변경
-        //        matchCode = matchInfo.matchCode
-        //        myUid = matchInfo.myUid
-        //        mateUid = matchInfo.mateUid
-        //        myCharacter = matchInfo.myCharacter
-        //        mateCharacter = matchInfo.mateCharacter
+        self.matchInfo = matchInfo
         
         self.runningCoopViewModel = RunningCoopViewModel(
             goalDistance: goalDistance,
-            myCharacter: myCharacter,
-            mateCharacter: mateCharacter,
-            matchCode: matchCode,
-            myUid: myUid,
-            mateUid: mateUid
+            myCharacter: matchInfo.myCharacter,
+            mateCharacter: matchInfo.mateCharacter,
+            matchCode: matchInfo.matchCode,
+            myUid: matchInfo.myUid,
+            mateUid: matchInfo.mateUid
         )
         
         super.init(nibName: nil, bundle: nil)
@@ -55,6 +44,7 @@ final class RunningCoopViewController: BaseViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
+    // MARK: - Lifecycle
     override func loadView() {
         self.view = rootView
     }
@@ -82,11 +72,11 @@ final class RunningCoopViewController: BaseViewController {
         
         // Firestore로부터 메이트 거리 수신
         FirestoreService.shared
-            .observeMateProgress(matchCode: matchCode, mateUid: mateUid)
+            .observeMateProgress(matchCode: matchInfo.matchCode, mateUid: matchInfo.mateUid)
             .bind(to: mateDistanceRelay)
             .disposed(by: disposeBag)
         
-        FirestoreService.shared.listenToMatchStatus(matchCode: matchCode)
+        FirestoreService.shared.listenToMatchStatus(matchCode: matchInfo.matchCode)
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] data in
                 guard let self = self else { return }
@@ -113,6 +103,7 @@ final class RunningCoopViewController: BaseViewController {
             .disposed(by: disposeBag)
     }
     
+    // MARK: - Binding
     override func bindViewModel() {
         super.bindViewModel()
         
@@ -170,7 +161,7 @@ final class RunningCoopViewController: BaseViewController {
     }
     
     private func navigateToFinish(success: Bool, myDistance: Double) {
-        let avatarType = AvatarType(rawValue: self.myCharacter) ?? .kaepy
+        let avatarType = AvatarType(rawValue: self.matchInfo.myCharacter) ?? .kaepy
         
         let finishVM = FinishViewModel(
             mode: .cooperation,
@@ -183,9 +174,9 @@ final class RunningCoopViewController: BaseViewController {
         )
         
         let vc = FinishViewController(
-            uid: myUid,
-            mateUid: mateUid,
-            matchCode: matchCode,
+            uid: matchInfo.myUid,
+            mateUid: matchInfo.mateUid,
+            matchCode: matchInfo.matchCode,
             viewModel: finishVM
         )
         vc.modalPresentationStyle = .fullScreen
@@ -203,6 +194,7 @@ final class RunningCoopViewController: BaseViewController {
             }
         )
     }
+    
     // 상대가 위치 권한 거부 시 알림 띄우고 홈으로 이동 처리
     func showMateLocationRejectedAlert() {
         rootView.showQuitAlert(
@@ -211,10 +203,10 @@ final class RunningCoopViewController: BaseViewController {
                 guard let self = self else { return }
                 // 여기서 matchStatus를 "finished" 등으로 변경
                 FirestoreService.shared
-                    .updateMatchStatus(matchCode: self.matchCode, status: "finished")
+                    .updateMatchStatus(matchCode: self.matchInfo.matchCode, status: "finished")
                     .subscribe(onCompleted: {
                         // 탭바 진입
-                        let tabBarVC = TabBarController(uid: self.myUid)
+                        let tabBarVC = TabBarController(uid: self.matchInfo.myUid)
                         tabBarVC.modalPresentationStyle = .fullScreen
                         if let window = UIApplication.shared.connectedScenes
                             .compactMap({ ($0 as? UIWindowScene)?.keyWindow })
@@ -229,6 +221,7 @@ final class RunningCoopViewController: BaseViewController {
             }
         )
     }
+    
     // 위치 권한 거부 시 시스템 알림 띄우기
     private func showLocationDeniedAlert() {
         let alert = UIAlertController(
@@ -247,11 +240,11 @@ final class RunningCoopViewController: BaseViewController {
         alert.addAction(UIAlertAction(title: "메인화면으로 이동", style: .cancel, handler: { [weak self] _ in
             guard let self = self else { return }
             FirestoreService.shared
-                .updateMatchStatus(matchCode: self.matchCode, status: "cancelLocation")
+                .updateMatchStatus(matchCode: self.matchInfo.matchCode, status: "cancelLocation")
                 .subscribe(
                     onCompleted: {
                         print("matchStatus: cancelLocation 저장 완료")
-                        let tabBarVC = TabBarController(uid: self.myUid)
+                        let tabBarVC = TabBarController(uid: self.matchInfo.myUid)
                         tabBarVC.modalPresentationStyle = .fullScreen
                         if let window = UIApplication.shared.connectedScenes
                             .compactMap({ ($0 as? UIWindowScene)?.keyWindow })


### PR DESCRIPTION
close #389 
<!-- close #No(이슈 넘버 등록하면 자동으로 이슈가 닫힙니다. 이슈를 닫고 싶지 않다면, 즉 해당 이슈의 작업이 아직 끝나지 않았다면 닫지 않습니다.) -->

## *⛳️ Work Description*

<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

### FirestoreService 에 인코딩을 적용
#### Codable 모델 생성
- UserDocument
- MatchDocument
#### 추가된 파일
```
FitMate/
├─ Common/
│  ├─ Auth/ 
│  ├─ Firestore/ 
│  ├─ Model/     // 디렉터리 새로 추가
│  │  ├─ MatchDocument.swift // 운동 경기 정보 문서 모델
│  │  └─ UserDocument.swift // 사용자 정보 문서 모델
```

### 수정된 코드
#### 1. Firestore 문서 생성 시, 인코딩 사용하도록 코드 수정 
- 인코딩을 사용하도록 수정한 이유
  - 타입 안정성 → 키 오타나 타입 불일치 오류를 컴파일 시점에 잡을 수 있음
  - 중복 코드 감소 → 매번 딕셔너리 만드는 수고 없음
  - 데이터 구조 변경 시 유지보수 용이 → 모델만 수정하면 저장 로직 자동 반영

@ServerTimestamp, @DocumentID 같은 편리한 어노테이션 제공
#### 2. `do { try ... } catch { ... }` 구문이 추가 되었습니다.
- 추가 이유: 에러가 두 단계로 나뉘었기 때문
  - 예전 코드(setData([String: Any]))는 인코딩 단계가 없어 던지는(throw) 에러가 없음
  - 바꾼 코드(setData(from: user))는 Codable 인코더가 먼저 동작. 이 인코딩은 throw 가능
예) 모델에 인코딩 불가 타입(예: UIColor), 잘못된 CodingKeys, 지원 안 되는 중첩 구조/값 등이 있으면 네트워크 요청 전에 실패됨.

그래서 사전에 인코딩 단계에서 확인 필요
- 동기(사전) 실패: 인코딩 단계 → try가 필요, catch에서 처리
- 비동기(후행) 실패: 실제 Firestore 쓰기 → 완료 핸들러 error에서 처리

즉, do–try–catch를 넣은 이유는 “인코딩 실패(동기 예외)”를 안전하게 잡기 위함.

## *📸 Screenshot*
- 코드적으로 리팩토링한 부분이기 때문에  스크릿샷 대응 불가
<!-- 구현한 부분의 시뮬레이터 스크린샷을 올려주시면 됩니다. -->
<!-- 기기대응을 위해 사이즈가 다른 기기별로 스크린샷을 올리기도 합니다. -->
<!-- 움직이는 동작일 경우, 시뮬레이터 영상을 녹화하고 gif로 저장하여 드래그 앤 드롭을 통해 업로드하면 됩니다. -->

## *📢 To Reviewers*

<!-- 이 PR을 리뷰하는 사람들에게 할 말이 있다면 작성하시면 됩니다. -->

- 코드리뷰 부탁드립니다.

## *✅ Checklist*

<!-- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다. -->

- [x]  주석 및 프린트문 제거 확인.
- [x]  컨벤션 준수 확인.
