### PR TITLE
[Refactor] #391 코인 보상 `FinishVC` -> `FinishVM` 으로 이동

### DIFF
--- a/FitMate/FitMate/Scene/Finish/View/FinishViewController.swift
+++ b/FitMate/FitMate/Scene/Finish/View/FinishViewController.swift
@@ -8,14 +8,7 @@ class FinishViewController: BaseViewController {
     private let finishView = FinishView()
     private let viewModel: FinishViewModel
     
-    let uid: String
-    let mateUid: String
-    let matchCode: String
-    
-    init(uid: String, mateUid: String, matchCode: String, viewModel: FinishViewModel) {
-        self.uid = uid
-        self.mateUid = mateUid
-        self.matchCode = matchCode
+    init(viewModel: FinishViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }

--- a/FitMate/FitMate/Scene/Finish/View/FinishViewController.swift
+++ b/FitMate/FitMate/Scene/Finish/View/FinishViewController.swift
@@ -29,19 +29,13 @@ class FinishViewController: BaseViewController {
         } else {
             SoundManage.shared.playFail()
         }
-        
-        let reward = calculateReward(
-            exerciseType: viewModel.sport,
-            goalValue: viewModel.goal,
-            mode: viewModel.mode,
-            isWin: viewModel.success
-        )
-        
-        finishView.updateReward(text: "\(reward)", hideCoin: viewModel.success)
     }
     
     override func bindViewModel() {
-        let output = viewModel.transform(input: .init())
+        let input = FinishViewModel.Input(
+            rewardTap: finishView.rewardButton.rx.tap.asSignal()
+        )
+        let output = viewModel.transform(input: input)
         
         output.modeText
             .drive(onNext: { [weak self] text in
@@ -83,159 +77,24 @@ class FinishViewController: BaseViewController {
             .drive(onNext: { [weak self] name in self?.finishView.updateCharacter(name) })
             .disposed(by: disposeBag)
         
-        // 게임 결과 저장
-        finishView.rewardButton.rx.tap
-            .bind { [weak self] in
+        // 저장 완료 → 화면 전환
+        output.saveCompleted
+            .emit(onNext: { [weak self] in
                 guard let self else { return }
-                
-                if viewModel.success {
-                    SoundManage.shared.coinSound()
+                let tabBarVC = TabBarController(uid: viewModel.uid)
+                tabBarVC.modalPresentationStyle = .fullScreen
+                if let window = UIApplication.shared.connectedScenes
+                    .compactMap({ ($0 as? UIWindowScene)?.keyWindow }).first {
+                    window.rootViewController = tabBarVC
+                    window.makeKeyAndVisible()
                 }
-                
-                // 보상 결과
-                let reward = calculateReward(
-                    exerciseType: viewModel.sport,
-                    goalValue: viewModel.goal,
-                    mode: viewModel.mode,
-                    isWin: viewModel.success
-                )
-                
-                // 코인 가산
-                rewardCoins(coinAmount: reward)
-                
-                FirestoreService.shared.updateMatchResult(
-                    matchCode: self.matchCode,
-                    myUid: self.uid,
-                    mateUid: self.mateUid,
-                    mode: viewModel.mode,
-                    isWinner: viewModel.success,
-                    goal: viewModel.goal,
-                    myDistance: viewModel.myDistance,
-                    exerciseType: viewModel.sport
-                )
-                .andThen(
-                    self.viewModel.saveRecord(
-                        uid: self.uid,
-                        mateUid: self.mateUid,
-                        matchCode: self.matchCode
-                    )
-                )
-                .subscribe(onCompleted: {
-                    print("유저 기록 저장 완료")
-                    
-                    let tabBarVC = TabBarController(uid: self.uid)
-                    tabBarVC.modalPresentationStyle = .fullScreen
-                    if let window = UIApplication.shared.connectedScenes
-                        .compactMap({ ($0 as? UIWindowScene)?.keyWindow })
-                        .first {
-                        window.rootViewController = tabBarVC
-                        window.makeKeyAndVisible()
-                    }
-                }, onError: { error in
-                    print("유저 기록 저장 실패: \(error.localizedDescription)")
-                })
-                .disposed(by: self.disposeBag)
-            }
+            }).disposed(by: disposeBag)
+        
+        output.saveFailed
+            .emit(onNext: { errorMsg in
+                print("유저 기록 저장 실패: \(errorMsg)")
+                // 필요 시 토스트/알럿
+            })
             .disposed(by: disposeBag)
-    }
-    
-    /// 코인 보상 계산
-    private func calculateReward(
-        exerciseType: String,
-        goalValue: Int,    // km, 분, 개수(줄넘기)
-        mode: FinishViewModel.Mode,
-        isWin: Bool = false
-    ) -> Int {
-        // 운동 계수
-        let exerciseFactor: Double = {
-            switch exerciseType {
-            case "걷기", "달리기": return 1.5
-            case "자전거": return 1.0
-            case "플랭크": return 1.6
-            case "줄넘기": return 1.4
-            default: return 1.0
-            }
-        }()
-        
-        // 모드 계수
-        let modeFactor: Double = {
-            switch mode {
-            case .cooperation: return isWin ? 0.5 : 0.0
-            case .battle: return isWin ? 1.0 : 0.0
-            }
-        }()
-        
-        // 지속 보너스 계수
-        let durationBonus: Double = {
-            switch exerciseType {
-            case "걷기":
-                if goalValue < 5 { return 0.5 }
-                else if goalValue < 11 { return 1.0 }
-                else if goalValue < 16 { return 1.5 }
-                else if goalValue < 20 { return 1.8 }
-                else { return 2.0 }
-            case "달리기":
-                if goalValue < 5 { return 0.5 }
-                else if goalValue < 11 { return 1.0 }
-                else if goalValue < 16 { return 1.5 }
-                else if goalValue < 20 { return 1.8 }
-                else if goalValue < 26 { return 2.0 }
-                else if goalValue < 30 { return 2.5 }
-                else if goalValue < 36 { return 3.0 }
-                else { return 4.0 }
-            case "자전거":
-                if goalValue < 11 { return 0.5 }
-                else if goalValue < 15 { return 0.8 }
-                else if goalValue < 30 { return 1.0 }
-                else if goalValue < 36 { return 1.5 }
-                else if goalValue < 40 { return 1.8 }
-                else if goalValue < 46 { return 2.0 }
-                else if goalValue < 50 { return 2.5 }
-                else if goalValue < 56 { return 3.0 }
-                else { return 4.0 }
-            case "플랭크":
-                if goalValue < 3 { return 0.5 }
-                else if goalValue < 4 { return 0.7 }
-                else if goalValue < 5 { return 0.9 }
-                else if goalValue < 6 { return 1.2 }
-                else if goalValue < 7 { return 1.5 }
-                else if goalValue < 8 { return 1.8 }
-                else if goalValue < 9 { return 2.0 }
-                else if goalValue < 10 { return 2.3 }
-                else { return 2.5 }
-            case "줄넘기":
-                if goalValue < 400 { return 0.5 }
-                else if goalValue < 700 { return 0.8 }
-                else if goalValue < 1000 { return 1.0 }
-                else if goalValue < 1300 { return 1.3 }
-                else if goalValue < 1600 { return 1.6 }
-                else if goalValue < 1900 { return 2.0 }
-                else { return 2.5 }
-            default:
-                return 1.0
-            }
-        }()
-        
-        let reward = (exerciseFactor * 100 * modeFactor * durationBonus).rounded(.toNearestOrEven)
-        return Int((reward / 10.0).rounded() * 10)
-    }
-    
-    /// 코인 보상 지급
-    private func rewardCoins(coinAmount: Int = 10) {
-        FirestoreService.shared.fetchDocument(collectionName: "users", documentName: self.uid)
-            .subscribe(
-                onSuccess: { [weak self] data in
-                    guard let self else { return }
-                    
-                    let myCoin = data["coin"] as? Int
-                    
-                    FirestoreService.shared.updateDocument(collectionName: "users", documentName: self.uid, fields: ["coin": (myCoin ?? 0) + coinAmount])
-                        .subscribe()
-                        .disposed(by: self.disposeBag)
-                    
-                }, onFailure: { error in
-                    print(" 문서 가져오기 실패: \(error.localizedDescription)")
-                }
-            ).disposed(by: disposeBag)
     }
 }

--- a/FitMate/FitMate/Scene/Finish/ViewModel/FinishViewModel.swift
+++ b/FitMate/FitMate/Scene/Finish/ViewModel/FinishViewModel.swift
@@ -9,7 +9,9 @@ final class FinishViewModel: ViewModelType {
         case cooperation
     }
     
-    struct Input { }
+    struct Input {
+        let rewardTap: Signal<Void> // 보상 버튼 탭
+    }
     
     struct Output {
         let modeText: Driver<String>
@@ -19,8 +21,11 @@ final class FinishViewModel: ViewModelType {
         let resultText: Driver<String>
         let resultImageName: Driver<String>
         let characterImageName: Driver<String>
+        let saveCompleted: Signal<Void> // 저장 완료 트리거 (VC에서 화면전환)
+        let saveFailed: Signal<String> // 저장 에러
     }
     
+    // MARK: - Inputs (생성자 주입)
     let mode: Mode
     let sport: String
     let goal: Int
@@ -29,41 +34,14 @@ final class FinishViewModel: ViewModelType {
     let success: Bool
     let avatarType: AvatarType
     
-    init(mode: Mode, sport: String, goal: Int, goalUnit: String, myDistance: Double = 0.0, avatarType: AvatarType, success: Bool) {
-        self.mode = mode
-        self.sport = sport
-        self.goal = goal
-        self.goalUnit = goalUnit
-        self.myDistance = myDistance      // 실제 달성 거리 (ex. 2.4)
-        self.avatarType = avatarType
-        self.success = success
-    }
     // 외부 필요 파라미터 (보상/저장에 쓰이는 식별자)
     let uid: String
     let mateUid: String
     let matchCode: String
     
-    func transform(input: Input) -> Output {
-        let modeText = Observable.just(mode == .battle ? "대결 모드" : "협력 모드")
-        let goalText = Observable.just("\(sport) \(goal)\(goalUnit)")
-        let reward = Observable.just("\(rewardCoin)")
-        let hideCoin = Observable.just(!success)
-        let myDistance: Double // 실제 달성 거리 (ex. 2.4Km)
-        let result = Observable.just(resultMessage)
-        let resultImage = Observable.just(success ? "win" : "Lose")
-        let characterImage = Observable.just(success ? avatarType.rawValue : "\(avatarType.rawValue)Lose")
-        
-        
-        return Output(
-            modeText: modeText.asDriver(onErrorJustReturn: ""),
-            goalText: goalText.asDriver(onErrorJustReturn: ""),
-            rewardText: reward.asDriver(onErrorJustReturn: ""),
-            hideCoin: hideCoin.asDriver(onErrorJustReturn: true),
-            resultText: result.asDriver(onErrorJustReturn: ""),
-            resultImageName: resultImage.asDriver(onErrorJustReturn: ""),
-            characterImageName: characterImage.asDriver(onErrorJustReturn: "")
-        )
-    }
+    private let disposeBag = DisposeBag()
+    private let saveCompletedRelay = PublishRelay<Void>()
+    private let saveFailedRelay = PublishRelay<String>()
     
     // 간단한 보상 계산 로직
     private var rewardCoin: Int {
@@ -120,6 +98,171 @@ final class FinishViewModel: ViewModelType {
         self.myDistance = myDistance      // 실제 달성 거리 (ex. 2.4)
         self.avatarType = avatarType
         self.success = success
+    }
+    
+    func transform(input: Input) -> Output {
+        let modeText = Observable.just(mode == .battle ? "대결 모드" : "협력 모드")
+        let goalText = Observable.just("\(sport) \(goal)\(goalUnit)")
+        // VC에 있던 상세 보상 계산을 그대로 ViewModel로 옮김
+        let rewardValue = calculateReward(exerciseType: sport,
+                                          goalValue: goal,
+                                          mode: mode,
+                                          isWin: success)
+        let reward = Observable.just("\(rewardCoin)")
+        let hideCoin = Observable.just(!success)
+        let myDistance: Double // 실제 달성 거리 (ex. 2.4Km)
+        let result = Observable.just(resultMessage)
+        let resultImage = Observable.just(success ? "win" : "Lose")
+        let characterImage = Observable.just(success ? avatarType.rawValue : "\(avatarType.rawValue)Lose")
+        
+        // 버튼 탭 → 코인 지급 + 경기 결과저장 + 기록 저장
+        input.rewardTap.emit(onNext: { [weak self] in
+            guard let self else { return }
+            if self.success {
+                SoundManage.shared.coinSound()
+            }
+            
+            let reward = rewardValue
+            
+            // 1) 코인 가산
+            self.rewardCoins(coinAmount: reward)
+            // 2) 경기 결과 업데이트
+                .andThen(
+                    FirestoreService.shared.updateMatchResult(
+                        matchCode: self.matchCode,
+                        myUid: self.uid,
+                        mateUid: self.mateUid,
+                        mode: self.mode,
+                        isWinner: self.success,
+                        goal: self.goal,
+                        myDistance: self.myDistance,
+                        exerciseType: self.sport
+                    )
+                )
+            // 3) 운동 기록 저장
+                .andThen(self.saveRecord(uid: self.uid, mateUid: self.mateUid, matchCode: self.matchCode))
+                .subscribe(
+                    onCompleted: { [weak self] in
+                        self?.saveCompletedRelay.accept(())
+                    },
+                    onError: { [weak self] error in
+                        self?.saveFailedRelay.accept(error.localizedDescription)
+                    }
+                )
+                .disposed(by: self.disposeBag)
+        }).disposed(by: disposeBag)
+        
+        
+        return Output(
+            modeText: modeText.asDriver(onErrorJustReturn: ""),
+            goalText: goalText.asDriver(onErrorJustReturn: ""),
+            rewardText: reward.asDriver(onErrorJustReturn: ""),
+            hideCoin: hideCoin.asDriver(onErrorJustReturn: true),
+            resultText: result.asDriver(onErrorJustReturn: ""),
+            resultImageName: resultImage.asDriver(onErrorJustReturn: ""),
+            characterImageName: characterImage.asDriver(onErrorJustReturn: ""),
+            saveCompleted: saveCompletedRelay.asSignal(),
+            saveFailed: saveFailedRelay.asSignal()
+        )
+    }
+}
+
+// MARK: - 코인 보상
+extension FinishViewModel {
+    /// 코인 보상 계산
+    private func calculateReward(
+        exerciseType: String,
+        goalValue: Int,    // km, 분, 개수(줄넘기)
+        mode: FinishViewModel.Mode,
+        isWin: Bool = false
+    ) -> Int {
+        
+        // 운동 계수
+        let exerciseFactor: Double = {
+            switch exerciseType {
+            case "걷기", "달리기": return 1.5
+            case "자전거": return 1.0
+            case "플랭크": return 1.6
+            case "줄넘기": return 1.4
+            default: return 1.0
+            }
+        }()
+        
+        // 모드 계수
+        let modeFactor: Double = {
+            switch mode {
+            case .cooperation: return isWin ? 0.5 : 0.0
+            case .battle: return isWin ? 1.0 : 0.0
+            }
+        }()
+        
+        // 지속 보너스 계수
+        let durationBonus: Double = {
+            switch exerciseType {
+            case "걷기":
+                if goalValue < 5 { return 0.5 }
+                else if goalValue < 11 { return 1.0 }
+                else if goalValue < 16 { return 1.5 }
+                else if goalValue < 20 { return 1.8 }
+                else { return 2.0 }
+            case "달리기":
+                if goalValue < 5 { return 0.5 }
+                else if goalValue < 11 { return 1.0 }
+                else if goalValue < 16 { return 1.5 }
+                else if goalValue < 20 { return 1.8 }
+                else if goalValue < 26 { return 2.0 }
+                else if goalValue < 30 { return 2.5 }
+                else if goalValue < 36 { return 3.0 }
+                else { return 4.0 }
+            case "자전거":
+                if goalValue < 11 { return 0.5 }
+                else if goalValue < 15 { return 0.8 }
+                else if goalValue < 30 { return 1.0 }
+                else if goalValue < 36 { return 1.5 }
+                else if goalValue < 40 { return 1.8 }
+                else if goalValue < 46 { return 2.0 }
+                else if goalValue < 50 { return 2.5 }
+                else if goalValue < 56 { return 3.0 }
+                else { return 4.0 }
+            case "플랭크":
+                if goalValue < 3 { return 0.5 }
+                else if goalValue < 4 { return 0.7 }
+                else if goalValue < 5 { return 0.9 }
+                else if goalValue < 6 { return 1.2 }
+                else if goalValue < 7 { return 1.5 }
+                else if goalValue < 8 { return 1.8 }
+                else if goalValue < 9 { return 2.0 }
+                else if goalValue < 10 { return 2.3 }
+                else { return 2.5 }
+            case "줄넘기":
+                if goalValue < 400 { return 0.5 }
+                else if goalValue < 700 { return 0.8 }
+                else if goalValue < 1000 { return 1.0 }
+                else if goalValue < 1300 { return 1.3 }
+                else if goalValue < 1600 { return 1.6 }
+                else if goalValue < 1900 { return 2.0 }
+                else { return 2.5 }
+            default:
+                return 1.0
+            }
+        }()
+        
+        let reward = (exerciseFactor * 100 * modeFactor * durationBonus).rounded(.toNearestOrEven)
+        return Int((reward / 10.0).rounded() * 10)
+    }
+    
+    func rewardCoins(coinAmount: Int) -> Completable {
+        guard coinAmount > 0 else { return .empty() }
+        return FirestoreService.shared.fetchDocument(collectionName: "users", documentName: self.uid)
+            .flatMapCompletable { data in
+                let current = data["coin"] as? Int ?? 0
+                return FirestoreService.shared.updateDocument(
+                    collectionName: "users",
+                    documentName: self.uid,
+                    fields: ["coin": current + coinAmount]
+                )
+                .asCompletable() // updateDocument 가 Single<Void>을 반환하여 Single<Void> → Completable 로 변환
+            }
     }
 }
 

--- a/FitMate/FitMate/Scene/Finish/ViewModel/FinishViewModel.swift
+++ b/FitMate/FitMate/Scene/Finish/ViewModel/FinishViewModel.swift
@@ -38,6 +38,10 @@ final class FinishViewModel: ViewModelType {
         self.avatarType = avatarType
         self.success = success
     }
+    // 외부 필요 파라미터 (보상/저장에 쓰이는 식별자)
+    let uid: String
+    let mateUid: String
+    let matchCode: String
     
     func transform(input: Input) -> Output {
         let modeText = Observable.just(mode == .battle ? "대결 모드" : "협력 모드")
@@ -94,6 +98,28 @@ final class FinishViewModel: ViewModelType {
             다음번엔 꼭 성공하리...
             """
         }
+    }
+    
+    init(uid: String,
+         mateUid: String,
+         matchCode: String,
+         mode: Mode,
+         sport: String,
+         goal: Int,
+         goalUnit: String,
+         myDistance: Double = 0.0,
+         avatarType: AvatarType,
+         success: Bool) {
+        self.uid = uid
+        self.mateUid = mateUid
+        self.matchCode = matchCode
+        self.mode = mode
+        self.sport = sport
+        self.goal = goal
+        self.goalUnit = goalUnit
+        self.myDistance = myDistance      // 실제 달성 거리 (ex. 2.4)
+        self.avatarType = avatarType
+        self.success = success
     }
 }
 

--- a/FitMate/FitMate/Scene/JumpRope/JumpRopeBattle/View/JumpRopeBattleViewController.swift
+++ b/FitMate/FitMate/Scene/JumpRope/JumpRopeBattle/View/JumpRopeBattleViewController.swift
@@ -158,6 +158,9 @@ class JumpRopeBattleViewController: BaseViewController {
         let avatarType = AvatarType(rawValue: myCharacter) ?? .kaepy
         
         let finishVM = FinishViewModel(
+            uid: myUid,
+            mateUid: mateUid,
+            matchCode: matchCode,
             mode: .battle,
             sport: "줄넘기",
             goal: viewModel.goalCount,
@@ -168,9 +171,6 @@ class JumpRopeBattleViewController: BaseViewController {
         )
         
         let vc = FinishViewController(
-            uid: myUid,
-            mateUid: mateUid,
-            matchCode: matchCode,
             viewModel: finishVM
         )
         
@@ -192,6 +192,9 @@ class JumpRopeBattleViewController: BaseViewController {
                 let avatarType = AvatarType(rawValue: self.myCharacter) ?? .kaepy
                 
                 let finishVM = FinishViewModel(
+                    uid: myUid,
+                    mateUid: mateUid,
+                    matchCode: matchCode,
                     mode: .battle,
                     sport: "줄넘기",
                     goal: self.viewModel.goalCount,
@@ -202,11 +205,9 @@ class JumpRopeBattleViewController: BaseViewController {
                 )
                 
                 let vc = FinishViewController(
-                    uid: self.myUid,
-                    mateUid: self.mateUid,
-                    matchCode: self.matchCode,
                     viewModel: finishVM
                 )
+                
                 vc.modalPresentationStyle = .fullScreen
                 self.present(vc, animated: true)
             }

--- a/FitMate/FitMate/Scene/JumpRope/JumpRopeCoop/View/JumpRopeCoopViewController.swift
+++ b/FitMate/FitMate/Scene/JumpRope/JumpRopeCoop/View/JumpRopeCoopViewController.swift
@@ -141,6 +141,9 @@ class JumpRopeCoopViewController: BaseViewController {
         let avatarType = AvatarType(rawValue: self.myCharacter) ?? .kaepy
         
         let finishVM = FinishViewModel(
+            uid: myUid,
+            mateUid: mateUid,
+            matchCode: matchCode,
             mode: .cooperation,
             sport: "줄넘기",
             goal: viewModel.goalCount,
@@ -149,10 +152,11 @@ class JumpRopeCoopViewController: BaseViewController {
             avatarType: avatarType,
             success: success
         )
-        let vc = FinishViewController(uid: myUid,
-                                      mateUid: mateUid,
-                                      matchCode: matchCode,
-                                      viewModel: finishVM)
+        
+        let vc = FinishViewController(
+            viewModel: finishVM
+        )
+        
         vc.modalPresentationStyle = .fullScreen
         present(vc, animated: true)
     }

--- a/FitMate/FitMate/Scene/Plank/PlankCoop/View/PlankCoopViewController.swift
+++ b/FitMate/FitMate/Scene/Plank/PlankCoop/View/PlankCoopViewController.swift
@@ -21,8 +21,8 @@ final class PlankCoopViewController: BaseViewController {
     private let myCharacter: String      // 내 아바타
     private let mateCharacter: String    // 상대 아바타
     private let matchCode: String        // 경기 코드
-    private let myUID: String            // 내 UID
-    private let mateUID: String          // 상대 UID
+    private let myUid: String            // 내 UID
+    private let mateUid: String          // 상대 UID
     private let isInviter: Bool          // 내가 초대자인지 여부
     
     // matchCode: String, myUid: String, mateUid: String,  myCharacter: String, mateCharacter: String -> ,matchInfo: MatchInfo으로 변경
@@ -40,8 +40,8 @@ final class PlankCoopViewController: BaseViewController {
     ) {
         self.isInviter = isInviter
         self.matchCode = matchCode
-        self.myUID = myUID
-        self.mateUID = mateUID
+        self.myUid = myUID
+        self.mateUid = mateUID
         self.myCharacter = myCharacter
         self.mateCharacter = mateCharacter
         //        위에 5줄 하단 5줄 코드로 변경
@@ -239,8 +239,12 @@ final class PlankCoopViewController: BaseViewController {
     private func navigateToFinish(success: Bool) {
         // 내 아바타 타입 변환
         let avatarType = AvatarType(rawValue: self.myCharacter) ?? .kaepy
+        
         // 결과 화면용 뷰모델 생성
         let finishVM = FinishViewModel(
+            uid: myUid,
+            mateUid: mateUid,
+            matchCode: matchCode,
             mode: .cooperation,
             sport: "플랭크",
             goal: viewModel.goalMinutes,
@@ -249,13 +253,12 @@ final class PlankCoopViewController: BaseViewController {
             avatarType: avatarType,
             success: success
         )
+        
         // 결과 화면 푸시
         let vc = FinishViewController(
-            uid: myUID,
-            mateUid: mateUID,
-            matchCode: matchCode,
             viewModel: finishVM
         )
+        
         vc.modalPresentationStyle = .fullScreen
         present(vc, animated: true)
     }

--- a/FitMate/FitMate/Scene/Running/RunningBattle/View/RunningBattleViewController.swift
+++ b/FitMate/FitMate/Scene/Running/RunningBattle/View/RunningBattleViewController.swift
@@ -172,6 +172,9 @@ class RunningBattleViewController: BaseViewController {
         let avatarType = AvatarType(rawValue: self.myCharacter) ?? .kaepy
         
         let finishVM = FinishViewModel(
+            uid: myUid,
+            mateUid: mateUid,
+            matchCode: matchCode,
             mode: .battle,
             sport: exerciseType,
             goal: goalDistance,
@@ -180,12 +183,11 @@ class RunningBattleViewController: BaseViewController {
             avatarType: avatarType,
             success: success
         )
+        
         let vc = FinishViewController(
-            uid: myUid,
-            mateUid: mateUid,
-            matchCode: matchCode,
             viewModel: finishVM
         )
+        
         vc.modalPresentationStyle = .fullScreen
         present(vc, animated: true)
     }

--- a/FitMate/FitMate/Scene/Running/RunningCoop/View/RunningCoopViewController.swift
+++ b/FitMate/FitMate/Scene/Running/RunningCoop/View/RunningCoopViewController.swift
@@ -173,6 +173,9 @@ final class RunningCoopViewController: BaseViewController {
         let avatarType = AvatarType(rawValue: self.myCharacter) ?? .kaepy
         
         let finishVM = FinishViewModel(
+            uid: myUid,
+            mateUid: mateUid,
+            matchCode: matchCode,
             mode: .cooperation,
             sport: exerciseType,
             goal: goalDistance,
@@ -183,11 +186,9 @@ final class RunningCoopViewController: BaseViewController {
         )
         
         let vc = FinishViewController(
-            uid: myUid,
-            mateUid: mateUid,
-            matchCode: matchCode,
             viewModel: finishVM
         )
+        
         vc.modalPresentationStyle = .fullScreen
         present(vc, animated: true)
     }


### PR DESCRIPTION
close #391 
<!-- close #No(이슈 넘버 등록하면 자동으로 이슈가 닫힙니다. 이슈를 닫고 싶지 않다면, 즉 해당 이슈의 작업이 아직 끝나지 않았다면 닫지 않습니다.) -->

## *⛳️ Work Description*

<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

### 1. FinishVC → FinishVM 식별자 관리 책임 이동
- uid, mateUid, matchCode 변수를 FinishViewController에서 FinishViewModel로 옮김
- ViewController에서는 viewModel.uid, viewModel.mateUid, viewModel.matchCode 로 접근하도록 수정
- 중복 선언을 제거하고, 운동 경기 식별자 관리 책임을 ViewModel에 일원화

### 2. 코인 보상 `FinishVC` -> `FinishVM` 으로 이동
- 기존에 `FinishVC`에 있던 코인 보상로직을 `FinishVM`로 이동시킴

## *📸 Screenshot*

<!-- 구현한 부분의 시뮬레이터 스크린샷을 올려주시면 됩니다. -->
<!-- 기기대응을 위해 사이즈가 다른 기기별로 스크린샷을 올리기도 합니다. -->
<!-- 움직이는 동작일 경우, 시뮬레이터 영상을 녹화하고 gif로 저장하여 드래그 앤 드롭을 통해 업로드하면 됩니다. -->

## *📢 To Reviewers*

<!-- 이 PR을 리뷰하는 사람들에게 할 말이 있다면 작성하시면 됩니다. -->

- 코드리뷰 부탁드립니다.

## *✅ Checklist*

<!-- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다. -->

- [x]  주석 및 프린트문 제거 확인.
- [x]  컨벤션 준수 확인.
